### PR TITLE
Add reminder comment to PRs

### DIFF
--- a/__tests__/__snapshots__/pullrequest.test.ts.snap
+++ b/__tests__/__snapshots__/pullrequest.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pull requests Repos with stale bot PRs are processed 1`] = `
+Array [
+  Array [
+    Object {
+      "body": "Foo 327 bar",
+      "issue_number": 2,
+      "owner": "bcgov",
+      "repo": "hello6",
+    },
+  ],
+]
+`;

--- a/src/config/development.json
+++ b/src/config/development.json
@@ -3,5 +3,6 @@
     "authUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/auth",
     "tokenUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/token",
     "certsUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/certs"
-  }
+  },
+  "staleIssueMaxDaysOld": 90
 }

--- a/src/config/production.json
+++ b/src/config/production.json
@@ -3,5 +3,6 @@
     "authUrl": "https://sso.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/auth",
     "tokenUrl": "https://sso.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/token",
     "certsUrl": "https://sso.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/certs"
-  }
+  },
+  "staleIssueMaxDaysOld": 90
 }

--- a/src/config/test.json
+++ b/src/config/test.json
@@ -3,5 +3,6 @@
     "authUrl": "https://sso-test.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/auth",
     "tokenUrl": "https://sso-test.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/token",
     "certsUrl": "https://sso-test.pathfinder.gov.bc.ca/auth/realms/devhub/protocol/openid-connect/certs"
-  }
+  },
+  "staleIssueMaxDaysOld": 90
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,7 +63,8 @@ export const VALID_LICENSES = {
 
 export const TEXT_FILES = {
   HOWTO_PR: 'templates/howto_pull_request.md',
-  STALE_COMMENT: 'templates/stale_issue_comment.md',
+  STALE_ISSUE_COMMENT: 'templates/stale_issue_comment.md',
+  STALE_PR_COMMENT: 'templates/stale_pr_comment.md',
   WHY_COMPLY: 'templates/why-comply.md',
   WHY_LICENSE: 'templates/why-license.md',
 };

--- a/src/libs/handlers.ts
+++ b/src/libs/handlers.ts
@@ -24,7 +24,7 @@ import { Context } from 'probot';
 import { ACCESS_CONTROL } from '../constants';
 import { fetchComplianceFile, fetchConfigFile } from './ghutils';
 import { checkForStaleIssues, created } from './issue';
-import { addCollaboratorsToPullRequests, validatePullRequestIfRequired } from './pullrequest';
+import { addCollaboratorsToPullRequests, requestUpdateForPullRequest, validatePullRequestIfRequired } from './pullrequest';
 import { addLicenseIfRequired, addSecurityComplianceInfoIfRequired } from './repository';
 import { extractComplianceStatus } from './utils';
 
@@ -135,6 +135,7 @@ export const repositoryScheduled = async (context: Context, scheduler: any): Pro
 
     try {
         await addCollaboratorsToPullRequests(context, owner, repo);
+        await requestUpdateForPullRequest(context, owner, repo);
     } catch (err) {
         const message = `Unable to assign collaborators in ${repo}`;
         logger.error(`${message}, error = ${err.message}`);

--- a/src/libs/handlers.ts
+++ b/src/libs/handlers.ts
@@ -134,6 +134,7 @@ export const repositoryScheduled = async (context: Context, scheduler: any): Pro
     }
 
     try {
+        // Housekeeping of PRs that were created by the bot.
         await addCollaboratorsToPullRequests(context, owner, repo);
         await requestUpdateForPullRequest(context, owner, repo);
     } catch (err) {

--- a/src/libs/issue.ts
+++ b/src/libs/issue.ts
@@ -76,7 +76,7 @@ export const checkForStaleIssues = async (context: Context, config: RepoMountieC
     }
 
     const regex = /\[MAX_DAYS_OLD\]/gi;
-    const rawMessageBody: string = await loadTemplate(TEXT_FILES.STALE_COMMENT);
+    const rawMessageBody: string = await loadTemplate(TEXT_FILES.STALE_ISSUE_COMMENT);
     const body = rawMessageBody
       .replace(regex, `${config.staleIssue.maxDaysOld}`);
 

--- a/src/libs/pullrequest.ts
+++ b/src/libs/pullrequest.ts
@@ -24,8 +24,19 @@ import { PullState, RepoAffiliation } from './enums';
 import { assignUsersToIssue, fetchCollaborators, fetchPullRequests, RepoMountieConfig } from './ghutils';
 import { loadTemplate } from './utils';
 
+/**
+ * Add comment to stale PRs
+ * This func will add a comment to pull request that are
+ * older than a threshold of days, and that were originally
+ * created by the bot.
+ *
+ * @param {Context} context The event context context
+ * @param {string} owner The organization name
+ * @param {string} repo The repo name
+ * @returns A void promise, rejection for failure
+ */
 export const requestUpdateForPullRequest = async (
-  context: Context, owner: string, repo: string) => {
+  context: Context, owner: string, repo: string): Promise<void> => {
 
   const maxDaysOld = 0; // config.get('staleIssueMaxDaysOld');
   const aDate = new Date(Date.now() - (maxDaysOld * 24 * 60 * 60 * 1000));
@@ -62,6 +73,7 @@ export const requestUpdateForPullRequest = async (
 
   await Promise.all(promises);
 };
+
 /**
  * Add collaborators to pull requests
  * This func will assign repo collaborators with `admin` and

--- a/src/libs/pullrequest.ts
+++ b/src/libs/pullrequest.ts
@@ -37,8 +37,8 @@ export const requestUpdateForPullRequest = async (
     q: query,
     sort: 'updated',
   });
-  const issues = response.data.items
-    .filter(p => Object.values(PR_TITLES).includes(p.title.trim()));
+  const issues = response.data.items ? response.data.items
+    .filter(p => Object.values(PR_TITLES).includes(p.title.trim())) : [];
 
   if (issues.length === 0) {
     return;

--- a/src/libs/pullrequest.ts
+++ b/src/libs/pullrequest.ts
@@ -26,7 +26,7 @@ import { loadTemplate } from './utils';
 export const requestUpdateForPullRequest = async (
   context: Context, owner: string, repo: string) => {
 
-  const maxDaysOld = 0; //config.get('staleIssueMaxDaysOld');
+  const maxDaysOld = 0; // config.get('staleIssueMaxDaysOld');
   const aDate = new Date(Date.now() - (maxDaysOld * 24 * 60 * 60 * 1000));
   const timestamp = (aDate).toISOString().replace(/\.\d{3}\w$/, '');
   const query = `repo:${owner}/${repo} is:open updated:<${timestamp}`;
@@ -50,9 +50,9 @@ export const requestUpdateForPullRequest = async (
       repo,
     }));
   const foo = await Promise.all(x);
-  console.log(foo[0].data[0].body);
+  // console.log(foo[0].data[0].body);
 
-  const body = "Hello World";
+  const body = 'Hello World';
   const promises = issues.map(i =>
     context.github.issues.createComment({
       issue_number: i.number,

--- a/templates/stale_pr_comment.md
+++ b/templates/stale_pr_comment.md
@@ -1,0 +1,1 @@
+Hey, its been [DAYS_OLD] days since this PR was last updated. I'm sure everyone is busy, however, it would be appreciated if someone from the team puts this issue to bed. Thanks in Advance.


### PR DESCRIPTION
This feature allows the bot to check back on PRs it created and, if needed, add a comment to bump assignee. This will hopefully lead to better update in dealing with, and eventually merging the PR.

Fixes #57 