### PR TITLE
Allow the bot to process issues in addition to PRs.

### DIFF
--- a/__tests__/__snapshots__/pullrequest.test.ts.snap
+++ b/__tests__/__snapshots__/pullrequest.test.ts.snap
@@ -10,5 +10,13 @@ Array [
       "repo": "hello6",
     },
   ],
+  Array [
+    Object {
+      "body": "Foo 210 bar",
+      "issue_number": 3,
+      "owner": "bcgov",
+      "repo": "hello6",
+    },
+  ],
 ]
 `;

--- a/__tests__/collaborators.test.ts
+++ b/__tests__/collaborators.test.ts
@@ -32,6 +32,9 @@ const allOpenPulls = JSON.parse(fs.readFileSync(p1, 'utf8'));
 const p2 = path.join(__dirname, 'fixtures/repo-collaborators.json');
 const collaborators = JSON.parse(fs.readFileSync(p2, 'utf8'));
 
+const p4 = path.join(__dirname, 'fixtures/issues-and-pulls.json');
+const issuesAndPulls = JSON.parse(fs.readFileSync(p4, 'utf8'));
+
 jest.mock('../src/libs/ghutils', () => ({
     fetchPullRequests: jest.fn(),
     fetchCollaborators: jest.fn(),
@@ -58,26 +61,14 @@ describe('Collaborator assignment to PR', () => {
 
     it('Collaborators are assigned to two open PRs', async () => {
         // @ts-ignore
-        fetchPullRequests.mockReturnValue(Promise.resolve(allOpenPulls));
+        github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
+
         // @ts-ignore
         fetchCollaborators.mockReturnValue(Promise.resolve(collaborators));
 
         await addCollaboratorsToPullRequests(context, owner, repo);
 
         expect(assignUsersToIssue).toBeCalledTimes(2);
-    });
-
-    it('Collaborators are assigned to unassigned PR', async () => {
-        allOpenPulls[2].assignees = ['Rubble'];
-
-        // @ts-ignore
-        fetchPullRequests.mockReturnValue(Promise.resolve(allOpenPulls));
-        // @ts-ignore
-        fetchCollaborators.mockReturnValue(Promise.resolve(collaborators));
-
-        await addCollaboratorsToPullRequests(context, owner, repo);
-
-        expect(assignUsersToIssue).toBeCalledTimes(1);
     });
 
     it('A repo with no collaborators is skipped', async () => {

--- a/__tests__/collaborators.test.ts
+++ b/__tests__/collaborators.test.ts
@@ -20,7 +20,7 @@ import fs from 'fs';
 import path from 'path';
 import { Context } from 'probot';
 import { assignUsersToIssue, fetchCollaborators, fetchPullRequests } from '../src/libs/ghutils';
-import { addCollaboratorsToPullRequests } from '../src/libs/pullrequest';
+import { addCollaboratorsToMyIssues } from '../src/libs/pullrequest';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/member-added-event.json');
@@ -66,7 +66,7 @@ describe('Collaborator assignment to PR', () => {
         // @ts-ignore
         fetchCollaborators.mockReturnValue(Promise.resolve(collaborators));
 
-        await addCollaboratorsToPullRequests(context, owner, repo);
+        await addCollaboratorsToMyIssues(context, owner, repo);
 
         expect(assignUsersToIssue).toBeCalledTimes(2);
     });
@@ -77,7 +77,7 @@ describe('Collaborator assignment to PR', () => {
         // @ts-ignore
         fetchCollaborators.mockReturnValue(Promise.resolve([]));
 
-        await addCollaboratorsToPullRequests(context, owner, repo);
+        await addCollaboratorsToMyIssues(context, owner, repo);
 
         expect(assignUsersToIssue).not.toBeCalled();
     });
@@ -88,7 +88,7 @@ describe('Collaborator assignment to PR', () => {
         // @ts-ignore
         fetchCollaborators.mockReturnValue(Promise.resolve(collaborators));
 
-        await addCollaboratorsToPullRequests(context, owner, repo);
+        await addCollaboratorsToMyIssues(context, owner, repo);
 
         expect(assignUsersToIssue).not.toBeCalled();
     });
@@ -109,7 +109,7 @@ describe('Collaborator assignment to PR', () => {
         // @ts-ignore
         fetchCollaborators.mockReturnValue(Promise.resolve(collabs));
 
-        await addCollaboratorsToPullRequests(context, owner, repo);
+        await addCollaboratorsToMyIssues(context, owner, repo);
 
         expect(assignUsersToIssue).not.toBeCalled();
     });

--- a/__tests__/handlers.test.ts
+++ b/__tests__/handlers.test.ts
@@ -22,7 +22,7 @@ import { Context } from 'probot';
 import { fetchConfigFile } from '../src/libs/ghutils';
 import { issueCommentCreated, memberAddedOrEdited, pullRequestOpened, repositoryDeleted, repositoryScheduled } from '../src/libs/handlers';
 import { checkForStaleIssues, created } from '../src/libs/issue';
-import { addCollaboratorsToPullRequests, validatePullRequestIfRequired } from '../src/libs/pullrequest';
+import { addCollaboratorsToMyIssues, validatePullRequestIfRequired } from '../src/libs/pullrequest';
 import { fetchComplianceMetrics } from '../src/libs/reporting';
 import { addLicenseIfRequired, addSecurityComplianceInfoIfRequired } from '../src/libs/repository';
 import helper from './src/helper';
@@ -47,9 +47,9 @@ jest.mock('../src/libs/reporting', () => ({
 }));
 
 jest.mock('../src/libs/pullrequest', () => ({
-    addCollaboratorsToPullRequests: jest.fn(),
+    addCollaboratorsToMyIssues: jest.fn(),
     validatePullRequestIfRequired: jest.fn(),
-    requestUpdateForPullRequest: jest.fn(),
+    requestUpdateForMyIssues: jest.fn(),
 }));
 
 jest.mock('../src/libs/repository', () => ({
@@ -89,7 +89,7 @@ describe('GitHub event handlers', () => {
 
         await memberAddedOrEdited(context);
 
-        expect(addCollaboratorsToPullRequests).toBeCalled();
+        expect(addCollaboratorsToMyIssues).toBeCalled();
     });
 
     it('Member edited handler', async () => {
@@ -98,7 +98,7 @@ describe('GitHub event handlers', () => {
 
         await memberAddedOrEdited(context);
 
-        expect(addCollaboratorsToPullRequests).toBeCalled();
+        expect(addCollaboratorsToMyIssues).toBeCalled();
     });
 
     it('Pull request created from bad org rejected', async () => {
@@ -107,7 +107,7 @@ describe('GitHub event handlers', () => {
 
         await pullRequestOpened(context);
 
-        expect(addCollaboratorsToPullRequests).not.toBeCalled();
+        expect(addCollaboratorsToMyIssues).not.toBeCalled();
         expect(fetchConfigFile).not.toBeCalled();
         expect(validatePullRequestIfRequired).not.toBeCalled();
     });
@@ -119,7 +119,7 @@ describe('GitHub event handlers', () => {
 
         await pullRequestOpened(context);
 
-        expect(addCollaboratorsToPullRequests).toBeCalled();
+        expect(addCollaboratorsToMyIssues).toBeCalled();
         expect(fetchConfigFile).not.toBeCalled();
         expect(validatePullRequestIfRequired).not.toBeCalled();
     });
@@ -131,7 +131,7 @@ describe('GitHub event handlers', () => {
 
         await pullRequestOpened(context);
 
-        expect(addCollaboratorsToPullRequests).not.toBeCalled();
+        expect(addCollaboratorsToMyIssues).not.toBeCalled();
         expect(fetchConfigFile).toBeCalled();
         expect(validatePullRequestIfRequired).toBeCalled();
     });
@@ -147,7 +147,7 @@ describe('GitHub event handlers', () => {
 
         await pullRequestOpened(context);
 
-        expect(addCollaboratorsToPullRequests).not.toBeCalled();
+        expect(addCollaboratorsToMyIssues).not.toBeCalled();
         expect(fetchConfigFile).toBeCalled();
         expect(validatePullRequestIfRequired).not.toBeCalled();
     });
@@ -187,7 +187,7 @@ describe('GitHub event handlers', () => {
 
         await repositoryScheduled(context, {});
 
-        expect(addCollaboratorsToPullRequests).not.toBeCalled();
+        expect(addCollaboratorsToMyIssues).not.toBeCalled();
         expect(fetchComplianceMetrics).not.toBeCalled();
         expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
         expect(addLicenseIfRequired).not.toBeCalled();
@@ -203,7 +203,7 @@ describe('GitHub event handlers', () => {
 
         await repositoryScheduled(context, scheduler);
 
-        expect(addCollaboratorsToPullRequests).not.toBeCalled();
+        expect(addCollaboratorsToMyIssues).not.toBeCalled();
         expect(fetchComplianceMetrics).not.toBeCalled();
         expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
         expect(addLicenseIfRequired).not.toBeCalled();
@@ -219,7 +219,7 @@ describe('GitHub event handlers', () => {
 
         await repositoryScheduled(context, scheduler);
 
-        expect(addCollaboratorsToPullRequests).toBeCalled();
+        expect(addCollaboratorsToMyIssues).toBeCalled();
         expect(fetchComplianceMetrics).toBeCalled();
         expect(addSecurityComplianceInfoIfRequired).toBeCalled();
         expect(addLicenseIfRequired).toBeCalled();
@@ -240,7 +240,7 @@ describe('GitHub event handlers', () => {
 
         await repositoryScheduled(context, scheduler);
 
-        expect(addCollaboratorsToPullRequests).toBeCalled();
+        expect(addCollaboratorsToMyIssues).toBeCalled();
         expect(fetchComplianceMetrics).toBeCalled();
         expect(addSecurityComplianceInfoIfRequired).toBeCalled();
         expect(addLicenseIfRequired).toBeCalled();
@@ -264,7 +264,7 @@ describe('GitHub event handlers', () => {
 
         await repositoryScheduled(context, scheduler);
 
-        expect(addCollaboratorsToPullRequests).toBeCalled();
+        expect(addCollaboratorsToMyIssues).toBeCalled();
         expect(fetchComplianceMetrics).toBeCalled();
         expect(addSecurityComplianceInfoIfRequired).toBeCalled();
         expect(addLicenseIfRequired).toBeCalled();

--- a/__tests__/pullrequest.test.ts
+++ b/__tests__/pullrequest.test.ts
@@ -20,16 +20,13 @@ import fs from 'fs';
 import path from 'path';
 import { Context } from 'probot';
 import { COMMANDS, ISSUE_TITLES } from '../src/constants';
-import { assignUsersToIssue, fetchCollaborators, fetchPullRequests } from '../src/libs/ghutils';
+import { assignUsersToIssue, fetchCollaborators } from '../src/libs/ghutils';
 import { addCollaboratorsToPullRequests, extractCommands, isValidPullRequestLength, requestUpdateForPullRequest, shouldIgnoredLengthCheck, validatePullRequestIfRequired } from '../src/libs/pullrequest';
 import { loadTemplate } from '../src/libs/utils';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/pull_request-opened-event.json');
 const issueOpenedEvent = JSON.parse(fs.readFileSync(p0, 'utf8'));
-
-const p1 = path.join(__dirname, 'fixtures/repo-get-pulls.json');
-const listPulls = JSON.parse(fs.readFileSync(p1, 'utf8'));
 
 const p2 = path.join(__dirname, 'fixtures/repo-get-collaborators-response.json');
 const collabs = JSON.parse(fs.readFileSync(p2, 'utf8'));
@@ -76,13 +73,13 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    fetchPullRequests.mockReturnValueOnce(Promise.resolve(listPulls.data));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
     // @ts-ignore
     fetchCollaborators.mockReturnValueOnce(Promise.resolve(collabs.data));
 
     await addCollaboratorsToPullRequests(context, owner, repo);
 
-    expect(fetchPullRequests).toBeCalled();
+    expect(github.search.issuesAndPullRequests).toBeCalled();
     expect(fetchCollaborators).toBeCalled();
     expect(assignUsersToIssue).toBeCalled();
   });
@@ -93,11 +90,11 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    fetchPullRequests.mockReturnValueOnce(Promise.resolve([]));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPullsEmpty));
 
     await addCollaboratorsToPullRequests(context, owner, repo);
 
-    expect(fetchPullRequests).toBeCalled();
+    expect(github.search.issuesAndPullRequests).toBeCalled();
     expect(fetchCollaborators).not.toBeCalled();
     expect(assignUsersToIssue).not.toBeCalled();
   });
@@ -108,13 +105,13 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    fetchPullRequests.mockReturnValueOnce(Promise.resolve(listPulls.data));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
     // @ts-ignore
     fetchCollaborators.mockReturnValueOnce(Promise.resolve([]));
 
     await addCollaboratorsToPullRequests(context, owner, repo);
 
-    expect(fetchPullRequests).toBeCalled();
+    expect(github.search.issuesAndPullRequests).toBeCalled();
     expect(fetchCollaborators).toBeCalled();
     expect(assignUsersToIssue).not.toBeCalled();
   });

--- a/__tests__/pullrequest.test.ts
+++ b/__tests__/pullrequest.test.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import { Context } from 'probot';
 import { COMMANDS, ISSUE_TITLES } from '../src/constants';
 import { assignUsersToIssue, fetchCollaborators } from '../src/libs/ghutils';
-import { addCollaboratorsToPullRequests, extractCommands, isValidPullRequestLength, requestUpdateForPullRequest, shouldIgnoredLengthCheck, validatePullRequestIfRequired } from '../src/libs/pullrequest';
+import { addCollaboratorsToMyIssues, extractCommands, isValidPullRequestLength, requestUpdateForMyIssues, shouldIgnoredLengthCheck, validatePullRequestIfRequired } from '../src/libs/pullrequest';
 import { loadTemplate } from '../src/libs/utils';
 import helper from './src/helper';
 
@@ -77,7 +77,7 @@ describe('Pull requests', () => {
     // @ts-ignore
     fetchCollaborators.mockReturnValueOnce(Promise.resolve(collabs.data));
 
-    await addCollaboratorsToPullRequests(context, owner, repo);
+    await addCollaboratorsToMyIssues(context, owner, repo);
 
     expect(github.search.issuesAndPullRequests).toBeCalled();
     expect(fetchCollaborators).toBeCalled();
@@ -92,7 +92,7 @@ describe('Pull requests', () => {
     // @ts-ignore
     github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPullsEmpty));
 
-    await addCollaboratorsToPullRequests(context, owner, repo);
+    await addCollaboratorsToMyIssues(context, owner, repo);
 
     expect(github.search.issuesAndPullRequests).toBeCalled();
     expect(fetchCollaborators).not.toBeCalled();
@@ -109,7 +109,7 @@ describe('Pull requests', () => {
     // @ts-ignore
     fetchCollaborators.mockReturnValueOnce(Promise.resolve([]));
 
-    await addCollaboratorsToPullRequests(context, owner, repo);
+    await addCollaboratorsToMyIssues(context, owner, repo);
 
     expect(github.search.issuesAndPullRequests).toBeCalled();
     expect(fetchCollaborators).toBeCalled();
@@ -233,7 +233,7 @@ describe('Pull requests', () => {
     // @ts-ignore
     github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPullsEmpty));
 
-    await requestUpdateForPullRequest(context, owner, repo);
+    await requestUpdateForMyIssues(context, owner, repo);
 
     expect(loadTemplate).not.toBeCalled();
     expect(github.issues.createComment).not.toBeCalled();
@@ -252,7 +252,7 @@ describe('Pull requests', () => {
     // @ts-ignore
     loadTemplate.mockReturnValueOnce('Foo [DAYS_OLD] bar');
 
-    await requestUpdateForPullRequest(context, owner, repo);
+    await requestUpdateForMyIssues(context, owner, repo);
 
     const call = github.issues.createComment.mock.calls
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,7 @@ export const SCHEDULER_DELAY: number = 24 * 60 * 60 * 1000; // one day
 
 export const COMMENT_TRIGGER_WORD = 'help';
 
-export const GITHUB_ID = 'repo-mountie';
+export const BOT_NAME = 'repo-mountie';
 
 export const REPO_CONFIG_FILE = 'rmconfig.json';
 

--- a/src/libs/handlers.ts
+++ b/src/libs/handlers.ts
@@ -24,7 +24,7 @@ import { Context } from 'probot';
 import { ACCESS_CONTROL } from '../constants';
 import { fetchConfigFile } from './ghutils';
 import { checkForStaleIssues, created } from './issue';
-import { addCollaboratorsToPullRequests, requestUpdateForPullRequest, validatePullRequestIfRequired } from './pullrequest';
+import { addCollaboratorsToMyIssues, requestUpdateForMyIssues, validatePullRequestIfRequired } from './pullrequest';
 import { fetchComplianceMetrics } from './reporting';
 import { addLicenseIfRequired, addSecurityComplianceInfoIfRequired, fixDeprecatedComplianceStatus, fixMinistryTopic } from './repository';
 
@@ -33,7 +33,7 @@ export const memberAddedOrEdited = async (context: Context): Promise<void> => {
     const repo = context.payload.repository.name;
 
     try {
-        await addCollaboratorsToPullRequests(context, owner, repo);
+        await addCollaboratorsToMyIssues(context, owner, repo);
     } catch (err) {
         const message = 'Unable to handel member event';
         logger.error(`${message}, error = ${err.message}`);
@@ -57,7 +57,7 @@ export const pullRequestOpened = async (context: Context): Promise<void> => {
 
     if (isFromBot) {
         try {
-            await addCollaboratorsToPullRequests(context, owner, repo);
+            await addCollaboratorsToMyIssues(context, owner, repo);
         } catch (err) {
             const message = `Unable to assign collaborators in ${repo}`;
             logger.error(`${message}, error = ${err.message}`);
@@ -137,9 +137,9 @@ export const repositoryScheduled = async (context: Context, scheduler: any): Pro
         // These are all independent func. Rather than call them each in a
         // try/catch I'm bundling them.
         await Promise.all([
-            addCollaboratorsToPullRequests(context, owner, repo),
+            addCollaboratorsToMyIssues(context, owner, repo),
             fixDeprecatedComplianceStatus(context, owner, repo),
-            requestUpdateForPullRequest(context, owner, repo),
+            requestUpdateForMyIssues(context, owner, repo),
             addLicenseIfRequired(context, scheduler),
             addSecurityComplianceInfoIfRequired(context, scheduler),
             fetchComplianceMetrics(context),

--- a/src/libs/pullrequest.ts
+++ b/src/libs/pullrequest.ts
@@ -36,7 +36,7 @@ import { loadTemplate } from './utils';
  * @param {string} repo The repo name
  * @returns A void promise, rejection for failure
  */
-export const requestUpdateForPullRequest = async (
+export const requestUpdateForMyIssues = async (
   context: Context, owner: string, repo: string): Promise<void> => {
 
   const maxDaysOld = config.get('staleIssueMaxDaysOld');
@@ -89,7 +89,7 @@ export const requestUpdateForPullRequest = async (
  * @param {Context} context The event context context
  * @returns True if the PR should be ignored, False otherwise
  */
-export const addCollaboratorsToPullRequests = async (
+export const addCollaboratorsToMyIssues = async (
   context: Context, owner: string, repo: string) => {
 
   try {

--- a/src/libs/pullrequest.ts
+++ b/src/libs/pullrequest.ts
@@ -20,9 +20,9 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import moment from 'moment';
 import { Context } from 'probot';
 import config from '../config';
-import { COMMANDS, ISSUE_TITLES, TEXT_FILES } from '../constants';
-import { PullState, RepoAffiliation } from './enums';
-import { assignUsersToIssue, fetchCollaborators, fetchPullRequests, RepoMountieConfig } from './ghutils';
+import { BOT_NAME, COMMANDS, TEXT_FILES } from '../constants';
+import { RepoAffiliation } from './enums';
+import { assignUsersToIssue, fetchCollaborators, RepoMountieConfig } from './ghutils';
 import { loadTemplate } from './utils';
 
 /**
@@ -42,7 +42,7 @@ export const requestUpdateForPullRequest = async (
   const maxDaysOld = config.get('staleIssueMaxDaysOld');
   const aDate = new Date(Date.now() - (maxDaysOld * 24 * 60 * 60 * 1000));
   const timestamp = (aDate).toISOString().replace(/\.\d{3}\w$/, '');
-  const query = `repo:${owner}/${repo} is:open updated:<${timestamp}`;
+  const query = `repo:${owner}/${repo} is:open updated:<${timestamp} author:app/${BOT_NAME}`;
 
   try {
     const response = await context.github.search.issuesAndPullRequests({
@@ -51,16 +51,14 @@ export const requestUpdateForPullRequest = async (
       q: query,
       sort: 'updated',
     });
-    const issues = response.data.items ? response.data.items
-      .filter(p => Object.values(ISSUE_TITLES).includes(p.title.trim())) : [];
 
-    if (issues.length === 0) {
+    if (response.data.items.length === 0) {
       return;
     }
 
     const rawMessageBody: string = await loadTemplate(TEXT_FILES.STALE_PR_COMMENT);
     const regex = /\[DAYS_OLD\]/gi;
-    const promises = issues.map(i => {
+    const promises = response.data.items.map(i => {
       const now = moment(Date.now());
       const diffInDays = now.diff(moment(i.updated_at), 'days');
       const body = rawMessageBody
@@ -95,29 +93,37 @@ export const addCollaboratorsToPullRequests = async (
   context: Context, owner: string, repo: string) => {
 
   try {
-    // filter for PRs created by the bot that don't have any
+    // filter for issues created by the bot that don't have any
     // assignees
-    const pulls: any = (await fetchPullRequests(context, PullState.Open))
-      .filter(p => p.assignees.length === 0)
-      .filter(p => Object.values(ISSUE_TITLES).includes(p.title.trim()));
 
-    if (pulls.length === 0) {
+    const query = `repo:${owner}/${repo} is:open is:pr no:assignee author:app/${BOT_NAME}`;
+    const response = await context.github.search.issuesAndPullRequests({
+      order: 'desc',
+      per_page: 100,
+      q: query,
+      sort: 'updated',
+    });
+    const totalCount = response.data.total_count ? response.data.total_count : 0;
+
+    if (totalCount === 0) {
       return;
     }
 
     // filter for collaborators who are admin or can write
+
     const assignees: any = (await fetchCollaborators(context, RepoAffiliation.Direct))
-      .filter((c) => (c.permissions.admin === true ||
-        c.permissions.push === true))
+      .filter((c) => c.permissions.admin === true)
       .map((u) => u.login);
 
     if (assignees.length === 0) {
       return;
     }
 
-    const promises = pulls.map(pr =>
+    // add assignees to the issue
+
+    const promises = response.data.items.map(i =>
       assignUsersToIssue(context, assignees, {
-        issue_number: pr.number,
+        issue_number: i.number,
         owner,
         repo,
       }));

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -21,7 +21,7 @@
 import { logger } from '@bcgov/common-nodejs-utils';
 import yaml from 'js-yaml';
 import { Context } from 'probot';
-import { BRANCHES, COMMIT_FILE_NAMES, COMMIT_MESSAGES, GITHUB_ID, ISSUE_TITLES, MINISTRY_SHORT_CODES, TEMPLATES, TEXT_FILES } from '../constants';
+import { BOT_NAME, BRANCHES, COMMIT_FILE_NAMES, COMMIT_MESSAGES, ISSUE_TITLES, MINISTRY_SHORT_CODES, TEMPLATES, TEXT_FILES } from '../constants';
 import { addFileViaPullRequest, checkIfFileExists, checkIfRefExists, fetchFileContent, hasPullRequestWithTitle } from './ghutils';
 import { extractMessage, loadTemplate } from './utils';
 
@@ -48,7 +48,7 @@ export const fixMinistryTopic = async (
     // Check if the repo already has an issue created by me
     // requesting topics be added.
 
-    const query = `repo:${owner}/${repo} is:open is:issue author:app/${GITHUB_ID} "${ISSUE_TITLES.ADD_TOPICS}"`;
+    const query = `repo:${owner}/${repo} is:open is:issue author:app/${BOT_NAME} "${ISSUE_TITLES.ADD_TOPICS}"`;
     const issuesResponse = await context.github.search.issuesAndPullRequests({
       order: 'desc',
       per_page: 100,


### PR DESCRIPTION
The bot will monitor for PRs that are un-assigned. This PR allows the bot to also watch for issues and assign them. Also, I did some cleanup of func names so they are more meaningfully now that issues are included.