### PR TITLE
Add new reporting script

### DIFF
--- a/scripts/report.ts
+++ b/scripts/report.ts
@@ -1,204 +1,187 @@
-//
-// Copyright © 2020 Province of British Columbia
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Created by Jason Leach on 2020-02-19.
-//
-
 import { logger } from '@bcgov/common-nodejs-utils';
+import Octokit from '@octokit/rest';
 import fs from 'fs';
+import yaml from 'js-yaml';
 import moment from 'moment';
-import { cleanup, ComplianceAudit, connect, RepoMeta } from '../src/db';
+import { COMMIT_FILE_NAMES, MINISTRY_SHORT_CODES } from '../src/constants';
 
-/**
- * Remove duplicate records
- * Prune records from the database where the status of the PIA or STRA
- * has not changed from the previous record.
- * @param {array} repoNames THe names of the repositories to prune
- * @returns Resolves when processing is complete, rejects on failure.
- */
-const prune = async (repoNames: []): Promise<void> => {
-    const piaRecordName = 'PIA';
-    const straRecordName = 'STRA';
+const org = 'bcgov';
+const token = process.env.GITHUB_TOKEN;
 
-    try {
-        for (const name of repoNames) {
-            const dupes: any = [];
-            const records = await ComplianceAudit.find({ repoName: name }, {}, { sort: { createdAt: 1 } });
+const fetchAllRepos = async (
+  octokit: any, owner: string, recordsPerPage: number = 100, startingPage: number = 1
+): Promise<any[]> => {
+  try {
+    let more = false;
+    let repos: any[] = [];
+    let currentPage: number = startingPage;
 
-            let last;
-            records.forEach((cur) => {
-                if (!last) {
-                    last = cur;
-                    return;
-                }
+    do {
+      const results = await octokit.repos.listForOrg({
+        org: owner,
+        per_page: recordsPerPage,
+        page: currentPage,
+        type: 'all',
+      });
 
-                const cPIA = cur.records.filter((v) => v.name === piaRecordName);
-                const cSTRA = cur.records.filter((v) => v.name === straRecordName);
-                const lPIA = last.records.filter((v) => v.name === piaRecordName);
-                const lSTRA = cur.records.filter((v) => v.name === straRecordName);
+      if (results.status !== 200) {
+        logger.info(`WARNING: Unexpected return code while fetching repos.`);
+      }
 
-                if ((cPIA.status === lPIA.status) && cSTRA.status === lSTRA.status) {
-                    dupes.push(cur._id);
-                    return;
-                }
+      repos = repos.concat(results.data);
+      more = results.data.length > 0;
+      currentPage++;
 
-                last = cur;
-            });
+    } while (more);
 
-            await ComplianceAudit.deleteMany({
-                _id: { $in: dupes },
-            });
-        }
-    } catch (err) {
-        const message = 'Unable to prune records';
-        logger.error(`${message}, error = ${err.message}`);
-    }
+    return repos;
+  } catch (err) {
+    logger.error(`Unable to fetch all repos for org ${owner}`);
+
+    return [];
+  }
 };
 
-/**
- * Bucket sort records by ministry
- * @param {array} records The compliance records
- * @returns A dictionary of records where the key is the ministry
- */
-const sortByMinistry = (records: any[]): any =>
-    records.reduce((acc, cur) => {
-        if (!(cur.ministry in acc)) {
-            acc[cur.ministry] = [];
-        }
-        acc[cur.ministry].push(cur);
+const fetchFileContent = async (
+  octokit: any, owner: string, repo: string, path: string
+): Promise<Buffer | undefined> => {
+  try {
+    const response = await octokit.repos.getContents(
+      {
+        owner,
+        repo,
+        path,
+      }
+    );
 
-        return acc;
-    }, {});
+    const data: any = response.data;
 
-/**
- * Convert an array of compliance records to CSV with header
- * @param {array} data The compliance records
- * @returns A string formatted as CSV with header fields.
- */
-const formatAsCSV = (data: any[]): string => {
-    const header: any = ['ministry', 'repoName', 'productLead'];
+    if (data.content && data.type !== 'file') {
+      throw new Error('No content returned or wrong file type.');
+    }
+
+    return Buffer.from(data.content, 'base64');
+  } catch (err) {
+    logger.info(`The repo ${repo} does not does not contain ${path}`);
+
+    return;
+  }
+};
+
+const fetchOrgCodesForRepo = async (octokit: any, repo: string): Promise<string[]> => {
+
+  try {
+    const response = await octokit.repos.listTopics({
+      owner: org,
+      repo,
+    });
+    const { names } = response.data;
+
+    return MINISTRY_SHORT_CODES.filter(c => names.includes(c.toLowerCase()));
+  } catch (err) {
+    const message = `Unable to fetch topics for repo ${repo}`;
+    logger.error(`${message}, error = ${err.message}`);
+
+    return [];
+  }
+}
+
+const formatAsCSV = (records: any[]): string[] => {
+
+  const header = ['repoName'];
+  const data: any = []
+  for (const r of records) {
+    const { repo, spec } = r;
     const lines: any = [];
 
-    // Build the CSV file, one line for each record in the
-    // input data.
-    data.forEach((d) => {
-        const status: any = [];
-        // Each data item will have a PIA and STRA record; its not clear if they
-        // will always be in the same order so they are added to the header and
-        // CSV dynamically.
-        // TODO:(jl) Better to sort alphabetically and just pull out the first
-        // two records?
-        d.records.forEach((r) => {
-            const prefix = r.name.toLowerCase();
-            if (!header.includes(`${prefix}Status`) && !header.includes(`${prefix}UpdatedAt`)) {
-                header.push(`${prefix}Status`);
-                header.push(`${prefix}UpdatedAt`);
-            }
-            // / add to the status array, joined to the CSV later
-            status.push(`${r.status},${moment(r.updatedAt).format('MM/DD/YY')}`);
-        });
-        // add the line to the CSV array
-        lines.push(`${d.ministry},${d.repoName},${d.productLead},${status.join(',')}`);
-    });
+    for (const s of spec.sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    })) {
+      const { name, status } = s;
+      const lastUpdated = s['last-updated'];
 
-    // insert the header at the front of the array
-    lines.splice(0, 0, header.join(','));
+      if (!header.includes(`${name}Status`) && !header.includes(`${name}UpdatedAt`)) {
+        header.push(`${name}Status`);
+        header.push(`${name}UpdatedAt`);
+      }
 
-    return lines.join('\n');
-};
-
-/**
- * Generate the compliance report
- * This func will generate a compliance report in CSV format
- * with header(s). One file will be created for each sorting key
- * which in this context is the ministry.
- * @param {array} data The compliance records
- */
-const report = (compliance: []): void => {
-    const sorted = sortByMinistry(compliance);
-    const keys = Object.keys(sorted);
-
-    keys.forEach((k) => {
-        const lines = formatAsCSV(sorted[k]);
-        fs.writeFileSync(`./data/${k}.csv`, lines);
-    });
-};
-
-/**
- * Merge repo metadata with compliance audit record
- * @param {Object[]} compliance The compliance records
- * @param {Object[]} meta Repository metadata records
- * @returns An array of compliance records populated with additional metadata.
- */
-const merge = (compliance, meta): any[] => {
-    const merged: any = [];
-    compliance.forEach((c) => {
-        const repodata = meta.find((m) => m.repository === c.repoName);
-        if (repodata) {
-            merged.push(
-                {
-                    ...c,
-                    ministry: repodata.ministry,
-                    ministryOrg: repodata.org,
-                    productLead: repodata.productLead,
-                }
-            );
-        } else if (c.topics && c.topics.length > 0) {
-            merged.push(
-                {
-                    ...c,
-                    ministry: c.topics.pop(),
-                    ministryOrg: '',
-                    productLead: '',
-                }
-            );
-        }
-    });
-
-    return merged;
-};
-
-/**
- * Main functionality
- */
-const main = async (): Promise<void> => {
-    try {
-        // Connect to the database
-        await connect();
-
-        // Prune duplicate records from the database. We're only interested in
-        // changes over time.
-        const reponames = await ComplianceAudit.find({}, { repoName: 1, _id: 0 }).distinct('repoName');
-        await prune(reponames);
-
-        // Fetch the metadata scraped from OCP and merge it (where possible) into
-        // the compliance records. This information populates the `ministry`
-        // field on which the records will be sorted and reported.
-        const meta: any = await RepoMeta.find({}, { gitOrg: 0, buildConfigName: 0, _id: 0 }).lean();
-        const compliance: any = await ComplianceAudit.find().lean();
-        const merged: any = merge(compliance, meta);
-
-        // Generate a series of CSV report files.
-        report(merged);
-    } catch (err) {
-        const message = `Unable to open database connection`;
-        throw new Error(`${message}, error = ${err.message}`);
-    } finally {
-        // Close database connections
-        cleanup();
+      lines.push(`${status},${moment(lastUpdated).format('MM/DD/YY')}`);
     }
+
+    data.push(header.join(','));
+    data.push(`${repo},${lines.join(',')}`);
+  }
+
+  return data;
 };
+
+const main = async () => {
+  const data = {};
+  const stats = {
+    missingMinistryCode: 0,
+    missingComplianceFile: 0,
+    hasManyMinistryCode: 0,
+  };
+
+  // @ts-ignore
+  const octokit = new Octokit({
+    auth: token,
+  });
+
+  const repos = await fetchAllRepos(octokit, org);
+
+  for (const r of repos) {
+
+    const orgCodes = await fetchOrgCodesForRepo(octokit, r.name);
+    if (orgCodes.length > 1) {
+      logger.info(`WARNING: The repo ${r.name} has multiple org codes.`);
+      logger.info(`         ${orgCodes}`);
+      logger.info(`         Skipping...`);
+
+      stats.hasManyMinistryCode++;
+
+      continue;
+    }
+
+    const myOrgCode = orgCodes.pop();
+
+    if (!myOrgCode) {
+      logger.info(`The repo ${r.name} does not have a ministry code.`);
+      stats.missingMinistryCode++;
+
+      continue;
+    }
+
+    if (!data.hasOwnProperty(myOrgCode)) {
+      data[myOrgCode] = [];
+    }
+
+    const buff = await fetchFileContent(octokit, org, r.name, COMMIT_FILE_NAMES.COMPLIANCE);
+    if (!buff) {
+      stats.missingComplianceFile++;
+
+      continue;
+    }
+
+    const doc = yaml.safeLoad(buff.toString());
+    data[myOrgCode].push({
+      repo: r.name,
+      spec: doc.spec,
+    });
+  }
+
+  Object.keys(data).forEach((k) => {
+    const blarb = formatAsCSV(data[k]);
+    fs.writeFileSync(`./data/${k}.csv`, blarb.join('\n'));
+  });
+
+
+  logger.info('Statistics')
+  logger.info(`* ${repos.length} repos were processed for ${org}.`);
+  logger.info(`* ${stats.missingComplianceFile} repos missing a compliance file.`)
+  logger.info(`* ${stats.missingMinistryCode} repos missing a ministry code.`)
+  logger.info(`* ${stats.hasManyMinistryCode} repos have multiple a ministry codes.`)
+
+}
 
 main();


### PR DESCRIPTION
The only requirement we have is to report on the current state of the compliance file. To do this better the new reporting script runs directly against GitHub rather than uses the mongodb. This fixes the current issue and will greatly simplify the reporting process. Having the bot log to a db was a bit of a kludge (not really the bots job). The old bot reporting mechanics will be cleaned up as part of a later task.

Fixed #100