### PR TITLE
Modified checkForStaleIssues query to exclude neverstale labels

### DIFF
--- a/src/libs/issue.ts
+++ b/src/libs/issue.ts
@@ -64,7 +64,7 @@ export const checkForStaleIssues = async (
   const timestamp = aDate.toISOString().replace(/\.\d{3}\w$/, '');
   const owner = context.payload.repository.owner.login;
   const repo = context.payload.repository.name;
-  const query = `repo:${owner}/${repo} is:open updated:<${timestamp}`;
+  const query = `repo:${owner}/${repo} is:open updated:<${timestamp} -label:neverstale`;
 
   try {
     const response = await context.github.search.issuesAndPullRequests({

--- a/templates/stale_issue_comment.md
+++ b/templates/stale_issue_comment.md
@@ -3,3 +3,5 @@ Its often hard for people to acknowledge that some things are just not that impo
 ### Pro Tip
 
 - If you're sad and want to re-open this issue you'll have another [MAX_DAYS_OLD] days to address it.
+
+- Or, if you want me to ignore this issue and never close it again, add the label "neverstale".


### PR DESCRIPTION
Modified checkForStaleIssues to ignore issues with "neverstale" label.

Fixes #110 