### PR TITLE
Enhancement/lint tests

### DIFF
--- a/__tests__/authmware.test.ts
+++ b/__tests__/authmware.test.ts
@@ -28,7 +28,10 @@ import { isAuthorized } from '../src/libs/authmware';
 const path2 = path.join(__dirname, 'fixtures/jwt-decoded-sa-20181107.json');
 const saOk = JSON.parse(fs.readFileSync(path2, 'utf8'));
 
-const path3 = path.join(__dirname, 'fixtures/jwt-decoded-sa-badid-20181107.json');
+const path3 = path.join(
+  __dirname,
+  'fixtures/jwt-decoded-sa-badid-20181107.json'
+);
 const saBadId = JSON.parse(fs.readFileSync(path3, 'utf8'));
 
 describe('Authentication tests', () => {

--- a/__tests__/ghutils.test.ts
+++ b/__tests__/ghutils.test.ts
@@ -20,7 +20,21 @@ import fs from 'fs';
 import path from 'path';
 import { Context } from 'probot';
 import { COMMIT_FILE_NAMES, ISSUE_TITLES } from '../src/constants';
-import { addFileViaPullRequest, assignUsersToIssue, checkIfFileExists, checkIfRefExists, fetchCollaborators, fetchComplianceFile, fetchConfigFile, fetchContentsForFile, fetchFileContent, fetchPullRequests, hasPullRequestWithTitle, isOrgMember, labelExists } from '../src/libs/ghutils';
+import {
+  addFileViaPullRequest,
+  assignUsersToIssue,
+  checkIfFileExists,
+  checkIfRefExists,
+  fetchCollaborators,
+  fetchComplianceFile,
+  fetchConfigFile,
+  fetchContentsForFile,
+  fetchFileContent,
+  fetchPullRequests,
+  hasPullRequestWithTitle,
+  isOrgMember,
+  labelExists,
+} from '../src/libs/ghutils';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/repo-schedule-event.json');
@@ -44,181 +58,238 @@ const listCommits = JSON.parse(fs.readFileSync(p6, 'utf8'));
 const p7 = path.join(__dirname, 'fixtures/org-user-ismember.json');
 const memberhip = JSON.parse(fs.readFileSync(p7, 'utf8'));
 
-const p8 = path.join(__dirname, 'fixtures/repo-get-collaborators-response.json');
+const p8 = path.join(
+  __dirname,
+  'fixtures/repo-get-collaborators-response.json'
+);
 const collabs = JSON.parse(fs.readFileSync(p8, 'utf8'));
 
 describe('GitHub utility functions', () => {
-    let context;
-    const { github } = helper;
+  let context;
+  const { github } = helper;
 
-    beforeEach(() => {
-        context = new Context(repoScheduledEvent, github as any, {} as any);
-        context.payload.organization = {
-            login: 'bcgov',
-        };
-    });
+  beforeEach(() => {
+    context = new Context(repoScheduledEvent, github as any, {} as any);
+    context.payload.organization = {
+      login: 'bcgov',
+    };
+  });
 
-    afterEach(() => {
-        jest.clearAllMocks();
-        jest.resetAllMocks();
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
 
-    it('Labels should be fetched for lookup', async () => {
-        await labelExists(context, 'blarb');
-        expect(github.issues.listLabelsForRepo).toHaveBeenCalled();
-    });
+  it('Labels should be fetched for lookup', async () => {
+    await labelExists(context, 'blarb');
+    expect(github.issues.listLabelsForRepo).toHaveBeenCalled();
+  });
 
-    it('A file should be retrieved.', async () => {
-        github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
-        const data = await fetchFileContent(context, COMMIT_FILE_NAMES.COMPLIANCE);
+  it('A file should be retrieved.', async () => {
+    github.repos.getContents = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(complianceResponse));
+    const data = await fetchFileContent(context, COMMIT_FILE_NAMES.COMPLIANCE);
 
-        expect(data).toMatchSnapshot();
-    });
+    expect(data).toMatchSnapshot();
+  });
 
-    it('A file should not be retrieved.', async () => {
-        await expect(fetchFileContent(context, 'blarb.txt')).rejects.toThrow(Error);
-    });
+  it('A file should not be retrieved.', async () => {
+    await expect(fetchFileContent(context, 'blarb.txt')).rejects.toThrow(Error);
+  });
 
-    it('The compliance file should be retrieved.', async () => {
-        github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
-        const data = await fetchComplianceFile(context);
+  it('The compliance file should be retrieved.', async () => {
+    github.repos.getContents = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(complianceResponse));
+    const data = await fetchComplianceFile(context);
 
-        expect(github.repos.getContents).toHaveBeenCalled();
-        expect(data).toMatchSnapshot();
-    });
+    expect(github.repos.getContents).toHaveBeenCalled();
+    expect(data).toMatchSnapshot();
+  });
 
-    it('The config file should be retrieved.', async () => {
-        github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(configResponse));
-        const data = await fetchConfigFile(context);
+  it('The config file should be retrieved.', async () => {
+    github.repos.getContents = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(configResponse));
+    const data = await fetchConfigFile(context);
 
-        expect(github.repos.getContents).toHaveBeenCalled();
-        expect(data).toMatchSnapshot();
-    });
+    expect(github.repos.getContents).toHaveBeenCalled();
+    expect(data).toMatchSnapshot();
+  });
 
-    it('The ref should exists.', async () => {
-        github.git.getRef.mockReturnValueOnce(master);
-        const result = await checkIfRefExists(context, context.payload.repository.default_branch);
+  it('The ref should exists.', async () => {
+    github.git.getRef.mockReturnValueOnce(master);
+    const result = await checkIfRefExists(
+      context,
+      context.payload.repository.default_branch
+    );
 
-        expect(github.git.getRef).toHaveBeenCalled();
-        expect(result).toBeTruthy();
-    });
+    expect(github.git.getRef).toHaveBeenCalled();
+    expect(result).toBeTruthy();
+  });
 
-    it('The ref should not exists.', async () => {
-        github.git.getRef.mockReturnValueOnce(Promise.reject());
-        const result = await checkIfRefExists(context, context.payload.repository.default_branch);
+  it('The ref should not exists.', async () => {
+    github.git.getRef.mockReturnValueOnce(Promise.reject());
+    const result = await checkIfRefExists(
+      context,
+      context.payload.repository.default_branch
+    );
 
-        expect(github.git.getRef).toHaveBeenCalled();
-        expect(result).toBeFalsy();
-    });
+    expect(github.git.getRef).toHaveBeenCalled();
+    expect(result).toBeFalsy();
+  });
 
-    it('A file should be added by PR', async () => {
-        const owner = 'bcgov';
-        const repo = 'hello5';
-        github.git.getRef.mockReturnValueOnce(master);
+  it('A file should be added by PR', async () => {
+    const owner = 'bcgov';
+    const repo = 'hello5';
+    github.git.getRef.mockReturnValueOnce(master);
 
-        await addFileViaPullRequest(context, owner, repo, 'Hello', 'World',
-            'This is a body.', 'blarb', 'blarb.txt', 'some-data-here');
+    await addFileViaPullRequest(
+      context,
+      owner,
+      repo,
+      'Hello',
+      'World',
+      'This is a body.',
+      'blarb',
+      'blarb.txt',
+      'some-data-here'
+    );
 
-        expect(github.git.getRef).toHaveBeenCalled();
-        expect(github.pulls.create).toHaveBeenCalled();
-        expect(github.git.createRef).toHaveBeenCalled();
-        expect(github.repos.createOrUpdateFile).toHaveBeenCalled();
-    });
+    expect(github.git.getRef).toHaveBeenCalled();
+    expect(github.pulls.create).toHaveBeenCalled();
+    expect(github.git.createRef).toHaveBeenCalled();
+    expect(github.repos.createOrUpdateFile).toHaveBeenCalled();
+  });
 
-    it('Pull requests are retrieved', async () => {
-        github.pulls.list = jest.fn().mockReturnValueOnce(Promise.resolve(listPulls));
-        const results = await fetchPullRequests(context);
+  it('Pull requests are retrieved', async () => {
+    github.pulls.list = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(listPulls));
+    const results = await fetchPullRequests(context);
 
-        expect(results).toMatchSnapshot();
-    });
+    expect(results).toMatchSnapshot();
+  });
 
-    it('A pull request should not exists', async () => {
-        github.pulls.list = jest.fn().mockReturnValueOnce(Promise.resolve(listPulls));
-        const result = await hasPullRequestWithTitle(context, 'Hello');
+  it('A pull request should not exists', async () => {
+    github.pulls.list = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(listPulls));
+    const result = await hasPullRequestWithTitle(context, 'Hello');
 
-        expect(result).toBeFalsy();
-    });
+    expect(result).toBeFalsy();
+  });
 
-    it('A pull request should exists', async () => {
-        github.pulls.list = jest.fn().mockReturnValueOnce(Promise.resolve(listPulls));
-        const result = await hasPullRequestWithTitle(context, ISSUE_TITLES.ADD_LICENSE);
+  it('A pull request should exists', async () => {
+    github.pulls.list = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(listPulls));
+    const result = await hasPullRequestWithTitle(
+      context,
+      ISSUE_TITLES.ADD_LICENSE
+    );
 
-        expect(result).toBeTruthy();
-    });
+    expect(result).toBeTruthy();
+  });
 
-    it('Assigning an issue on GitHub should succeed', async () => {
-        github.issues.addAssignees = jest.fn().mockReturnValueOnce(Promise.resolve());
+  it('Assigning an issue on GitHub should succeed', async () => {
+    github.issues.addAssignees = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve());
 
-        await expect(assignUsersToIssue(context, ['blarb'])).resolves.toBeUndefined();
-    });
+    await expect(
+      assignUsersToIssue(context, ['blarb'])
+    ).resolves.toBeUndefined();
+  });
 
-    it('Assigning an issue on GitHub should fail', async () => {
-        github.issues.addAssignees = jest.fn().mockReturnValueOnce(Promise.reject());
+  it('Assigning an issue on GitHub should fail', async () => {
+    github.issues.addAssignees = jest
+      .fn()
+      .mockReturnValueOnce(Promise.reject());
 
-        await expect(assignUsersToIssue(context, ['blarb'])).rejects.toThrow();
-    });
+    await expect(assignUsersToIssue(context, ['blarb'])).rejects.toThrow();
+  });
 
-    it('File contents should be retrieved', async () => {
-        github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
-        github.repos.listCommits = jest.fn().mockReturnValueOnce(Promise.resolve(listCommits));
+  it('File contents should be retrieved', async () => {
+    github.repos.getContents = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(complianceResponse));
+    github.repos.listCommits = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(listCommits));
 
-        const results = await fetchContentsForFile(context, 'helo.yaml');
+    const results = await fetchContentsForFile(context, 'helo.yaml');
 
-        expect(github.repos.listCommits).toHaveBeenCalled();
-        expect(github.repos.getContents).toHaveBeenCalled();
-        expect(results).toMatchSnapshot();
-    });
+    expect(github.repos.listCommits).toHaveBeenCalled();
+    expect(github.repos.getContents).toHaveBeenCalled();
+    expect(results).toMatchSnapshot();
+  });
 
-    it('A user is a member of the organization', async () => {
-        github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.resolve(memberhip));
+  it('A user is a member of the organization', async () => {
+    github.orgs.checkMembership = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(memberhip));
 
-        const result = await isOrgMember(context, 'helloworld');
-        expect(result).toBeTruthy();
-    });
+    const result = await isOrgMember(context, 'helloworld');
+    expect(result).toBeTruthy();
+  });
 
-    it('A user is not a member of the organization', async () => {
-        const err: any = new Error('Nope');
-        err.code = 404;
+  it('A user is not a member of the organization', async () => {
+    const err: any = new Error('Nope');
+    err.code = 404;
 
-        github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.reject(err));
+    github.orgs.checkMembership = jest
+      .fn()
+      .mockReturnValueOnce(Promise.reject(err));
 
-        const result = await isOrgMember(context, 'helloworld');
-        expect(result).toBeFalsy();
-    });
+    const result = await isOrgMember(context, 'helloworld');
+    expect(result).toBeFalsy();
+  });
 
-    it('A user lookup fails unexpectedly', async () => {
-        const err: any = new Error('Nope');
+  it('A user lookup fails unexpectedly', async () => {
+    const err: any = new Error('Nope');
 
-        github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.reject(err));
+    github.orgs.checkMembership = jest
+      .fn()
+      .mockReturnValueOnce(Promise.reject(err));
 
-        await expect(isOrgMember(context, 'helloworld')).rejects.toThrow();
-    });
+    await expect(isOrgMember(context, 'helloworld')).rejects.toThrow();
+  });
 
-    it('A user lookup fails due to an unexpected http code', async () => {
-        memberhip.status = 512;
-        github.orgs.checkMembership = jest.fn().mockReturnValueOnce(Promise.resolve(memberhip));
+  it('A user lookup fails due to an unexpected http code', async () => {
+    memberhip.status = 512;
+    github.orgs.checkMembership = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(memberhip));
 
-        const result = await isOrgMember(context, 'helloworld');
-        expect(result).toBeFalsy();
-    });
+    const result = await isOrgMember(context, 'helloworld');
+    expect(result).toBeFalsy();
+  });
 
-    it('Return true if a file exists', async () => {
-        github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.resolve(complianceResponse));
+  it('Return true if a file exists', async () => {
+    github.repos.getContents = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(complianceResponse));
 
-        await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeTruthy();
-    });
+    await expect(
+      checkIfFileExists(context, 'hello.yaml')
+    ).resolves.toBeTruthy();
+  });
 
-    it('Return false if a file does not exist', async () => {
-        github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.reject());
+  it('Return false if a file does not exist', async () => {
+    github.repos.getContents = jest.fn().mockReturnValueOnce(Promise.reject());
 
-        await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeFalsy();
-    });
+    await expect(checkIfFileExists(context, 'hello.yaml')).resolves.toBeFalsy();
+  });
 
-    it('Fetching collaborators should succeed', async () => {
-        github.repos.listCollaborators = jest.fn().mockReturnValueOnce(Promise.resolve(collabs));
+  it('Fetching collaborators should succeed', async () => {
+    github.repos.listCollaborators = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(collabs));
 
-        const results = await fetchCollaborators(context);
+    const results = await fetchCollaborators(context);
 
-        expect(results).toMatchSnapshot();
-    });
+    expect(results).toMatchSnapshot();
+  });
 });

--- a/__tests__/handlers.test.ts
+++ b/__tests__/handlers.test.ts
@@ -20,10 +20,24 @@ import fs from 'fs';
 import path from 'path';
 import { Context } from 'probot';
 import { fetchConfigFile } from '../src/libs/ghutils';
-import { issueCommentCreated, memberAddedOrEdited, pullRequestOpened, repositoryCreated, repositoryDeleted, repositoryScheduled } from '../src/libs/handlers';
+import {
+  issueCommentCreated,
+  memberAddedOrEdited,
+  pullRequestOpened,
+  repositoryCreated,
+  repositoryDeleted,
+  repositoryScheduled,
+} from '../src/libs/handlers';
 import { checkForStaleIssues, created } from '../src/libs/issue';
-import { addCollaboratorsToMyIssues, validatePullRequestIfRequired } from '../src/libs/pullrequest';
-import { addLicenseIfRequired, addMinistryTopicIfRequired, addSecurityComplianceInfoIfRequired } from '../src/libs/repository';
+import {
+  addCollaboratorsToMyIssues,
+  validatePullRequestIfRequired,
+} from '../src/libs/pullrequest';
+import {
+  addLicenseIfRequired,
+  addMinistryTopicIfRequired,
+  addSecurityComplianceInfoIfRequired,
+} from '../src/libs/repository';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/member-added-event.json');
@@ -45,275 +59,275 @@ const p5 = path.join(__dirname, 'fixtures/repo-created-event.json');
 const repoCreatedEvent = JSON.parse(fs.readFileSync(p5, 'utf8'));
 
 jest.mock('../src/libs/pullrequest', () => ({
-    addCollaboratorsToMyIssues: jest.fn(),
-    validatePullRequestIfRequired: jest.fn(),
-    requestUpdateForMyIssues: jest.fn(),
+  addCollaboratorsToMyIssues: jest.fn(),
+  validatePullRequestIfRequired: jest.fn(),
+  requestUpdateForMyIssues: jest.fn(),
 }));
 
 jest.mock('../src/libs/repository', () => ({
-    addSecurityComplianceInfoIfRequired: jest.fn(),
-    addLicenseIfRequired: jest.fn(),
-    fixDeprecatedComplianceStatus: jest.fn(),
-    addMinistryTopicIfRequired: jest.fn(),
+  addSecurityComplianceInfoIfRequired: jest.fn(),
+  addLicenseIfRequired: jest.fn(),
+  fixDeprecatedComplianceStatus: jest.fn(),
+  addMinistryTopicIfRequired: jest.fn(),
 }));
 
 jest.mock('../src/libs/issue', () => ({
-    created: jest.fn(),
-    checkForStaleIssues: jest.fn(),
+  created: jest.fn(),
+  checkForStaleIssues: jest.fn(),
 }));
 
 jest.mock('../src/libs/ghutils', () => ({
-    fetchConfigFile: jest.fn(),
+  fetchConfigFile: jest.fn(),
 }));
 
 describe('GitHub event handlers', () => {
-    const { github } = helper;
-    const scheduler = {
-        stop: jest.fn(),
-    };
+  const { github } = helper;
+  const scheduler = {
+    stop: jest.fn(),
+  };
 
-    afterEach(() => {
-        jest.clearAllMocks();
-        jest.resetAllMocks();
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('Member added handler', async () => {
+    const event = JSON.parse(JSON.stringify(memberAddedEvent));
+    event.payload.organization.login = 'bcgov';
+    const context = new Context(event, github as any, {} as any);
+
+    await memberAddedOrEdited(context);
+
+    expect(addCollaboratorsToMyIssues).toBeCalled();
+  });
+
+  it('Member edited handler', async () => {
+    const event = JSON.parse(JSON.stringify(memberAddedEvent));
+    event.payload.organization.login = 'bcgov';
+    const context = new Context(event, github as any, {} as any);
+
+    await memberAddedOrEdited(context);
+
+    expect(addCollaboratorsToMyIssues).toBeCalled();
+  });
+
+  it('Pull request created from bad org rejected', async () => {
+    const event = JSON.parse(JSON.stringify(issueOpenedEvent));
+    event.payload.organization.login = 'fakeOrg';
+    const context = new Context(event, github as any, {} as any);
+
+    await pullRequestOpened(context);
+
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(fetchConfigFile).not.toBeCalled();
+    expect(validatePullRequestIfRequired).not.toBeCalled();
+  });
+
+  it('Pull request created by Bot is processed', async () => {
+    const event = JSON.parse(JSON.stringify(issueOpenedEvent));
+    event.payload.organization.login = 'bcgov';
+    event.payload.sender.type = 'Bot';
+    const context = new Context(event, github as any, {} as any);
+
+    await pullRequestOpened(context);
+
+    expect(addCollaboratorsToMyIssues).toBeCalled();
+    expect(fetchConfigFile).not.toBeCalled();
+    expect(validatePullRequestIfRequired).not.toBeCalled();
+  });
+
+  it('Pull request from repo with config processed', async () => {
+    const event = JSON.parse(JSON.stringify(issueOpenedEvent));
+    event.payload.organization.login = 'bcgov';
+    event.payload.sender.type = 'User';
+    const context = new Context(event, github as any, {} as any);
+
+    await pullRequestOpened(context);
+
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(fetchConfigFile).toBeCalled();
+    expect(validatePullRequestIfRequired).toBeCalled();
+  });
+
+  it('Pull request from repo without config skipped', async () => {
+    const event = JSON.parse(JSON.stringify(issueOpenedEvent));
+    event.payload.organization.login = 'bcgov';
+    event.payload.sender.type = 'User';
+    const context = new Context(event, github as any, {} as any);
+
+    // @ts-ignore
+    fetchConfigFile.mockImplementationOnce(() => {
+      throw new Error();
     });
 
-    it('Member added handler', async () => {
-        const event = JSON.parse(JSON.stringify(memberAddedEvent));
-        event.payload.organization.login = 'bcgov';
-        const context = new Context(event, github as any, {} as any);
+    await pullRequestOpened(context);
 
-        await memberAddedOrEdited(context);
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(fetchConfigFile).toBeCalled();
+    expect(validatePullRequestIfRequired).not.toBeCalled();
+  });
 
-        expect(addCollaboratorsToMyIssues).toBeCalled();
+  it('Comment created from bad org rejected', async () => {
+    const event = JSON.parse(JSON.stringify(issueCommentCreatedEvent));
+    event.payload.organization.login = 'fakeOrg';
+    event.payload.sender.type = 'User';
+    const context = new Context(event, github as any, {} as any);
+
+    await issueCommentCreated(context);
+
+    expect(created).not.toBeCalled();
+  });
+
+  it('Comment created by Bot is ignored', async () => {
+    const event = JSON.parse(JSON.stringify(issueCommentCreatedEvent));
+    event.payload.organization.login = 'bcgov';
+    event.payload.sender.type = 'Bot';
+    const context = new Context(event, github as any, {} as any);
+
+    await issueCommentCreated(context);
+
+    expect(created).not.toBeCalled();
+  });
+
+  it('Comment created by User is processed', async () => {
+    const event = JSON.parse(JSON.stringify(issueCommentCreatedEvent));
+    event.payload.organization.login = 'bcgov';
+    event.payload.sender.type = 'User';
+    const context = new Context(event, github as any, {} as any);
+
+    await issueCommentCreated(context);
+
+    expect(created).toBeCalled();
+  });
+
+  it('Scheduled repos from bad org rejected', async () => {
+    const event = JSON.parse(JSON.stringify(repoScheduledEvent));
+    event.payload.installation.account.login = 'fakeOrg';
+    const context = new Context(event, github as any, {} as any);
+
+    await repositoryScheduled(context, {});
+
+    expect(addMinistryTopicIfRequired).not.toBeCalled();
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
+    expect(addLicenseIfRequired).not.toBeCalled();
+    expect(fetchConfigFile).not.toBeCalled();
+    expect(checkForStaleIssues).not.toBeCalled();
+    expect(scheduler.stop).not.toBeCalled();
+  });
+
+  it('Scheduled repos that are archived are rejected', async () => {
+    const event = JSON.parse(JSON.stringify(repoScheduledEvent));
+    event.payload.installation.account.login = 'bcgov';
+    event.payload.repository.archived = true;
+    const context = new Context(event, github as any, {} as any);
+
+    await repositoryScheduled(context, scheduler);
+
+    expect(addMinistryTopicIfRequired).not.toBeCalled();
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
+    expect(addLicenseIfRequired).not.toBeCalled();
+    expect(fetchConfigFile).not.toBeCalled();
+    expect(checkForStaleIssues).not.toBeCalled();
+    expect(scheduler.stop).toBeCalled();
+  });
+
+  it('Scheduled repos without compliance file have one added', async () => {
+    const event = JSON.parse(JSON.stringify(repoScheduledEvent));
+    event.payload.installation.account.login = 'bcgov';
+    event.payload.repository.archived = false;
+    const context = new Context(event, github as any, {} as any);
+
+    await repositoryScheduled(context, scheduler);
+
+    expect(addMinistryTopicIfRequired).not.toBeCalled();
+    expect(addCollaboratorsToMyIssues).toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).toBeCalled();
+    expect(addLicenseIfRequired).toBeCalled();
+    expect(fetchConfigFile).toBeCalled();
+    expect(checkForStaleIssues).toBeCalled();
+    expect(scheduler.stop).not.toBeCalled();
+  });
+
+  it('Scheduled repos with compliance file have it skipped', async () => {
+    const event = JSON.parse(JSON.stringify(repoScheduledEvent));
+    event.payload.installation.account.login = 'bcgov';
+    event.payload.repository.archived = false;
+    const context = new Context(event, github as any, {} as any);
+
+    await repositoryScheduled(context, scheduler);
+
+    expect(addMinistryTopicIfRequired).not.toBeCalled();
+    expect(addCollaboratorsToMyIssues).toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).toBeCalled();
+    expect(addLicenseIfRequired).toBeCalled();
+    expect(fetchConfigFile).toBeCalled();
+    expect(checkForStaleIssues).toBeCalled();
+    expect(scheduler.stop).not.toBeCalled();
+  });
+
+  it('Scheduled repos without config file skip cultural policy', async () => {
+    const event = JSON.parse(JSON.stringify(repoScheduledEvent));
+    event.payload.installation.account.login = 'bcgov';
+    event.payload.repository.archived = false;
+    const context = new Context(event, github as any, {} as any);
+
+    // @ts-ignore
+    fetchConfigFile.mockImplementationOnce(() => {
+      throw new Error();
     });
 
-    it('Member edited handler', async () => {
-        const event = JSON.parse(JSON.stringify(memberAddedEvent));
-        event.payload.organization.login = 'bcgov';
-        const context = new Context(event, github as any, {} as any);
+    await repositoryScheduled(context, scheduler);
 
-        await memberAddedOrEdited(context);
+    expect(addMinistryTopicIfRequired).not.toBeCalled();
+    expect(addCollaboratorsToMyIssues).toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).toBeCalled();
+    expect(addLicenseIfRequired).toBeCalled();
+    expect(fetchConfigFile).toBeCalled();
+    expect(checkForStaleIssues).not.toBeCalled();
+    expect(scheduler.stop).not.toBeCalled();
+  });
 
-        expect(addCollaboratorsToMyIssues).toBeCalled();
-    });
+  it('Deleted repositories are unscheduled', async () => {
+    const event = JSON.parse(JSON.stringify(repoDeletedEvent));
+    event.payload.organization.login = 'bcgov';
+    const context = new Context(event, github as any, {} as any);
 
-    it('Pull request created from bad org rejected', async () => {
-        const event = JSON.parse(JSON.stringify(issueOpenedEvent));
-        event.payload.organization.login = 'fakeOrg';
-        const context = new Context(event, github as any, {} as any);
+    await repositoryDeleted(context, scheduler);
 
-        await pullRequestOpened(context);
+    expect(scheduler.stop).toBeCalled();
+  });
 
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(fetchConfigFile).not.toBeCalled();
-        expect(validatePullRequestIfRequired).not.toBeCalled();
-    });
+  it('Created repos have topics issue added', async () => {
+    const event = JSON.parse(JSON.stringify(repoCreatedEvent));
+    const context = new Context(event, github as any, {} as any);
 
-    it('Pull request created by Bot is processed', async () => {
-        const event = JSON.parse(JSON.stringify(issueOpenedEvent));
-        event.payload.organization.login = 'bcgov';
-        event.payload.sender.type = 'Bot';
-        const context = new Context(event, github as any, {} as any);
+    await repositoryCreated(context);
 
-        await pullRequestOpened(context);
+    expect(addMinistryTopicIfRequired).toBeCalled();
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
+    expect(addLicenseIfRequired).not.toBeCalled();
+    expect(fetchConfigFile).not.toBeCalled();
+    expect(checkForStaleIssues).not.toBeCalled();
+    expect(scheduler.stop).not.toBeCalled();
+  });
 
-        expect(addCollaboratorsToMyIssues).toBeCalled();
-        expect(fetchConfigFile).not.toBeCalled();
-        expect(validatePullRequestIfRequired).not.toBeCalled();
-    });
+  it('Created repos from the wrong org are skipped', async () => {
+    const event = JSON.parse(JSON.stringify(repoCreatedEvent));
+    event.payload.repository.owner.login = 'bacon';
 
-    it('Pull request from repo with config processed', async () => {
-        const event = JSON.parse(JSON.stringify(issueOpenedEvent));
-        event.payload.organization.login = 'bcgov';
-        event.payload.sender.type = 'User';
-        const context = new Context(event, github as any, {} as any);
+    const context = new Context(event, github as any, {} as any);
 
-        await pullRequestOpened(context);
+    await repositoryCreated(context);
 
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(fetchConfigFile).toBeCalled();
-        expect(validatePullRequestIfRequired).toBeCalled();
-    });
-
-    it('Pull request from repo without config skipped', async () => {
-        const event = JSON.parse(JSON.stringify(issueOpenedEvent));
-        event.payload.organization.login = 'bcgov';
-        event.payload.sender.type = 'User';
-        const context = new Context(event, github as any, {} as any);
-
-        // @ts-ignore
-        fetchConfigFile.mockImplementationOnce(() => {
-            throw new Error();
-        });
-
-        await pullRequestOpened(context);
-
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(fetchConfigFile).toBeCalled();
-        expect(validatePullRequestIfRequired).not.toBeCalled();
-    });
-
-    it('Comment created from bad org rejected', async () => {
-        const event = JSON.parse(JSON.stringify(issueCommentCreatedEvent));
-        event.payload.organization.login = 'fakeOrg';
-        event.payload.sender.type = 'User';
-        const context = new Context(event, github as any, {} as any);
-
-        await issueCommentCreated(context);
-
-        expect(created).not.toBeCalled();
-    });
-
-    it('Comment created by Bot is ignored', async () => {
-        const event = JSON.parse(JSON.stringify(issueCommentCreatedEvent));
-        event.payload.organization.login = 'bcgov';
-        event.payload.sender.type = 'Bot';
-        const context = new Context(event, github as any, {} as any);
-
-        await issueCommentCreated(context);
-
-        expect(created).not.toBeCalled();
-    });
-
-    it('Comment created by User is processed', async () => {
-        const event = JSON.parse(JSON.stringify(issueCommentCreatedEvent));
-        event.payload.organization.login = 'bcgov';
-        event.payload.sender.type = 'User';
-        const context = new Context(event, github as any, {} as any);
-
-        await issueCommentCreated(context);
-
-        expect(created).toBeCalled();
-    });
-
-    it('Scheduled repos from bad org rejected', async () => {
-        const event = JSON.parse(JSON.stringify(repoScheduledEvent));
-        event.payload.installation.account.login = 'fakeOrg';
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryScheduled(context, {});
-
-        expect(addMinistryTopicIfRequired).not.toBeCalled();
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
-        expect(addLicenseIfRequired).not.toBeCalled();
-        expect(fetchConfigFile).not.toBeCalled();
-        expect(checkForStaleIssues).not.toBeCalled();
-        expect(scheduler.stop).not.toBeCalled();
-    });
-
-    it('Scheduled repos that are archived are rejected', async () => {
-        const event = JSON.parse(JSON.stringify(repoScheduledEvent));
-        event.payload.installation.account.login = 'bcgov';
-        event.payload.repository.archived = true;
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryScheduled(context, scheduler);
-
-        expect(addMinistryTopicIfRequired).not.toBeCalled();
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
-        expect(addLicenseIfRequired).not.toBeCalled();
-        expect(fetchConfigFile).not.toBeCalled();
-        expect(checkForStaleIssues).not.toBeCalled();
-        expect(scheduler.stop).toBeCalled();
-    });
-
-    it('Scheduled repos without compliance file have one added', async () => {
-        const event = JSON.parse(JSON.stringify(repoScheduledEvent));
-        event.payload.installation.account.login = 'bcgov';
-        event.payload.repository.archived = false;
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryScheduled(context, scheduler);
-
-        expect(addMinistryTopicIfRequired).not.toBeCalled();
-        expect(addCollaboratorsToMyIssues).toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).toBeCalled();
-        expect(addLicenseIfRequired).toBeCalled();
-        expect(fetchConfigFile).toBeCalled();
-        expect(checkForStaleIssues).toBeCalled();
-        expect(scheduler.stop).not.toBeCalled();
-    });
-
-    it('Scheduled repos with compliance file have it skipped', async () => {
-        const event = JSON.parse(JSON.stringify(repoScheduledEvent));
-        event.payload.installation.account.login = 'bcgov';
-        event.payload.repository.archived = false;
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryScheduled(context, scheduler);
-
-        expect(addMinistryTopicIfRequired).not.toBeCalled();
-        expect(addCollaboratorsToMyIssues).toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).toBeCalled();
-        expect(addLicenseIfRequired).toBeCalled();
-        expect(fetchConfigFile).toBeCalled();
-        expect(checkForStaleIssues).toBeCalled();
-        expect(scheduler.stop).not.toBeCalled();
-    });
-
-    it('Scheduled repos without config file skip cultural policy', async () => {
-        const event = JSON.parse(JSON.stringify(repoScheduledEvent));
-        event.payload.installation.account.login = 'bcgov';
-        event.payload.repository.archived = false;
-        const context = new Context(event, github as any, {} as any);
-
-        // @ts-ignore
-        fetchConfigFile.mockImplementationOnce(() => {
-            throw new Error();
-        });
-
-        await repositoryScheduled(context, scheduler);
-
-        expect(addMinistryTopicIfRequired).not.toBeCalled();
-        expect(addCollaboratorsToMyIssues).toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).toBeCalled();
-        expect(addLicenseIfRequired).toBeCalled();
-        expect(fetchConfigFile).toBeCalled();
-        expect(checkForStaleIssues).not.toBeCalled();
-        expect(scheduler.stop).not.toBeCalled();
-    });
-
-    it('Deleted repositories are unscheduled', async () => {
-        const event = JSON.parse(JSON.stringify(repoDeletedEvent));
-        event.payload.organization.login = 'bcgov';
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryDeleted(context, scheduler);
-
-        expect(scheduler.stop).toBeCalled();
-    });
-
-    it('Created repos have topics issue added', async () => {
-        const event = JSON.parse(JSON.stringify(repoCreatedEvent));
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryCreated(context);
-
-        expect(addMinistryTopicIfRequired).toBeCalled();
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
-        expect(addLicenseIfRequired).not.toBeCalled();
-        expect(fetchConfigFile).not.toBeCalled();
-        expect(checkForStaleIssues).not.toBeCalled();
-        expect(scheduler.stop).not.toBeCalled();
-    });
-
-    it('Created repos from the wrong org are skipped', async () => {
-        const event = JSON.parse(JSON.stringify(repoCreatedEvent));
-        event.payload.repository.owner.login = 'bacon';
-
-        const context = new Context(event, github as any, {} as any);
-
-        await repositoryCreated(context);
-
-        expect(addMinistryTopicIfRequired).not.toBeCalled();
-        expect(addCollaboratorsToMyIssues).not.toBeCalled();
-        expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
-        expect(addLicenseIfRequired).not.toBeCalled();
-        expect(fetchConfigFile).not.toBeCalled();
-        expect(checkForStaleIssues).not.toBeCalled();
-        expect(scheduler.stop).not.toBeCalled();
-    });
+    expect(addMinistryTopicIfRequired).not.toBeCalled();
+    expect(addCollaboratorsToMyIssues).not.toBeCalled();
+    expect(addSecurityComplianceInfoIfRequired).not.toBeCalled();
+    expect(addLicenseIfRequired).not.toBeCalled();
+    expect(fetchConfigFile).not.toBeCalled();
+    expect(checkForStaleIssues).not.toBeCalled();
+    expect(scheduler.stop).not.toBeCalled();
+  });
 });

--- a/__tests__/issue.test.ts
+++ b/__tests__/issue.test.ts
@@ -26,7 +26,9 @@ import { loadTemplate } from '../src/libs/utils';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/issue_comment-event.json');
-const unassignedIssueCommentCreatedEvent = JSON.parse(fs.readFileSync(p0, 'utf8'));
+const unassignedIssueCommentCreatedEvent = JSON.parse(
+  fs.readFileSync(p0, 'utf8')
+);
 
 const p1 = path.join(__dirname, 'fixtures/rmconfig.json');
 const config = JSON.parse(fs.readFileSync(p1, 'utf8'));
@@ -54,7 +56,7 @@ jest.mock('../src/libs/robo', () => ({
 }));
 
 describe('Issues (and PRs)', () => {
-  let context
+  let context;
   const { github } = helper;
 
   beforeEach(() => {
@@ -67,7 +69,11 @@ describe('Issues (and PRs)', () => {
   });
 
   it('Comments from non-members are ignored', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
     // @ts-ignore
     isOrgMember.mockReturnValueOnce(Promise.resolve(false));
 
@@ -78,7 +84,11 @@ describe('Issues (and PRs)', () => {
   });
 
   it('Comments without commands are skipped', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
     context.payload.comment.body = 'I\'m a teapot';
 
     // @ts-ignore
@@ -91,7 +101,11 @@ describe('Issues (and PRs)', () => {
   });
 
   it('Comments with commands are processed', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
     context.payload.comment.body = '@repo-mountie help\n';
 
     // @ts-ignore
@@ -106,7 +120,11 @@ describe('Issues (and PRs)', () => {
   // TODO:(jl) Should be moved to repo?
 
   it('Repos configured to ignore stale issues ignored', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
 
     const myConfig = JSON.parse(JSON.stringify(config));
     delete myConfig.staleIssue;
@@ -123,9 +141,15 @@ describe('Issues (and PRs)', () => {
   });
 
   it('Repos without applicable stale label ok', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPulls)
+    );
     // @ts-ignore
     loadTemplate.mockReturnValueOnce(Promise.resolve(tempate));
 
@@ -144,9 +168,15 @@ describe('Issues (and PRs)', () => {
   });
 
   it('Repos with stale issues are commented, labeled and closed', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPulls)
+    );
     // @ts-ignore
     loadTemplate.mockReturnValueOnce(Promise.resolve(tempate));
 
@@ -162,9 +192,15 @@ describe('Issues (and PRs)', () => {
   });
 
   it('Repos without stale issues ignored', async () => {
-    context = new Context(unassignedIssueCommentCreatedEvent, github as any, {} as any);
+    context = new Context(
+      unassignedIssueCommentCreatedEvent,
+      github as any,
+      {} as any
+    );
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPullsEmpty));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPullsEmpty)
+    );
 
     await checkForStaleIssues(context, config);
 

--- a/__tests__/pullrequest.test.ts
+++ b/__tests__/pullrequest.test.ts
@@ -21,14 +21,24 @@ import path from 'path';
 import { Context } from 'probot';
 import { COMMANDS, ISSUE_TITLES } from '../src/constants';
 import { assignUsersToIssue, fetchCollaborators } from '../src/libs/ghutils';
-import { addCollaboratorsToMyIssues, extractCommands, isValidPullRequestLength, requestUpdateForMyIssues, shouldIgnoredLengthCheck, validatePullRequestIfRequired } from '../src/libs/pullrequest';
+import {
+  addCollaboratorsToMyIssues,
+  extractCommands,
+  isValidPullRequestLength,
+  requestUpdateForMyIssues,
+  shouldIgnoredLengthCheck,
+  validatePullRequestIfRequired,
+} from '../src/libs/pullrequest';
 import { loadTemplate } from '../src/libs/utils';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/pull_request-opened-event.json');
 const issueOpenedEvent = JSON.parse(fs.readFileSync(p0, 'utf8'));
 
-const p2 = path.join(__dirname, 'fixtures/repo-get-collaborators-response.json');
+const p2 = path.join(
+  __dirname,
+  'fixtures/repo-get-collaborators-response.json'
+);
 const collabs = JSON.parse(fs.readFileSync(p2, 'utf8'));
 
 const p3 = path.join(__dirname, 'fixtures/rmconfig.json');
@@ -73,7 +83,9 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPulls)
+    );
     // @ts-ignore
     fetchCollaborators.mockReturnValueOnce(Promise.resolve(collabs.data));
 
@@ -90,7 +102,9 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPullsEmpty));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPullsEmpty)
+    );
 
     await addCollaboratorsToMyIssues(context, owner, repo);
 
@@ -105,7 +119,9 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPulls)
+    );
     // @ts-ignore
     fetchCollaborators.mockReturnValueOnce(Promise.resolve([]));
 
@@ -131,7 +147,7 @@ describe('Pull requests', () => {
 
     const rv = await shouldIgnoredLengthCheck(commands);
 
-    expect(rv).toBeFalsy;
+    expect(rv).toBeFalsy();
   });
 
   it('No commands are processed correctly', () => {
@@ -231,7 +247,9 @@ describe('Pull requests', () => {
     const repo = 'hello5';
 
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPullsEmpty));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPullsEmpty)
+    );
 
     await requestUpdateForMyIssues(context, owner, repo);
 
@@ -248,13 +266,15 @@ describe('Pull requests', () => {
     response.data.items[0].title = ISSUE_TITLES.ADD_COMPLIANCE;
 
     // @ts-ignore
-    github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(response));
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(response)
+    );
     // @ts-ignore
     loadTemplate.mockReturnValueOnce('Foo [DAYS_OLD] bar');
 
     await requestUpdateForMyIssues(context, owner, repo);
 
-    const call = github.issues.createComment.mock.calls
+    const call = github.issues.createComment.mock.calls;
 
     expect(loadTemplate).toBeCalled();
     expect(github.issues.createComment).toBeCalled();

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -20,8 +20,19 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import { Context } from 'probot';
-import { addFileViaPullRequest, checkIfRefExists, fetchFileContent, hasPullRequestWithTitle } from '../src/libs/ghutils';
-import { addLicenseIfRequired, addMinistryTopicIfRequired, addSecurityComplianceInfoIfRequired, addWordsMatterIfRequire, fixDeprecatedComplianceStatus } from '../src/libs/repository';
+import {
+  addFileViaPullRequest,
+  checkIfRefExists,
+  fetchFileContent,
+  hasPullRequestWithTitle,
+} from '../src/libs/ghutils';
+import {
+  addLicenseIfRequired,
+  addMinistryTopicIfRequired,
+  addSecurityComplianceInfoIfRequired,
+  addWordsMatterIfRequire,
+  fixDeprecatedComplianceStatus,
+} from '../src/libs/repository';
 import { loadTemplate } from '../src/libs/utils';
 import helper from './src/helper';
 
@@ -46,326 +57,354 @@ const repoGetTopics = JSON.parse(fs.readFileSync(p6, 'utf8'));
 const p7 = path.join(__dirname, 'fixtures/repo-created-event.json');
 const repoCreated = JSON.parse(fs.readFileSync(p7, 'utf8'));
 
-
 jest.mock('../src/libs/ghutils', () => ({
-    addFileViaPullRequest: jest.fn(),
-    checkIfRefExists: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
-    extractMessage: jest.fn().mockReturnValue('Hello Message'),
-    hasPullRequestWithTitle: jest.fn().mockReturnValueOnce(Promise.resolve(false)),
-    loadTemplate: jest.fn().mockReturnValue('Hello'),
-    fetchFileContent: jest.fn(),
-    checkIfFileExists: jest.fn(),
+  addFileViaPullRequest: jest.fn(),
+  checkIfRefExists: jest.fn().mockReturnValueOnce(Promise.resolve(true)),
+  extractMessage: jest.fn().mockReturnValue('Hello Message'),
+  hasPullRequestWithTitle: jest
+    .fn()
+    .mockReturnValueOnce(Promise.resolve(false)),
+  loadTemplate: jest.fn().mockReturnValue('Hello'),
+  fetchFileContent: jest.fn(),
+  checkIfFileExists: jest.fn(),
 }));
 
 jest.mock('../src/libs/utils', () => ({
-    loadTemplate: jest.fn(),
-    extractMessage: jest.fn(),
+  loadTemplate: jest.fn(),
+  extractMessage: jest.fn(),
 }));
 
 describe('Repository management', () => {
-    let context;
-    const { github } = helper;
+  let context;
+  const { github } = helper;
 
-    beforeEach(() => {
-        context = undefined;
+  beforeEach(() => {
+    context = undefined;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('Adding a license should resolve', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    addFileViaPullRequest.mockImplementation(() => Promise.resolve());
+    await expect(addLicenseIfRequired(context, owner, repo)).resolves.toBe(
+      undefined
+    );
+  });
+
+  it('Adding a license should fail because ref missing', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(false);
+    await expect(addLicenseIfRequired(context, owner, repo)).resolves.toBe(
+      undefined
+    );
+  });
+
+  it('Adding a license should fail because pr exists', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true);
+    // @ts-ignore
+    hasPullRequestWithTitle.mockReturnValueOnce(true);
+    await expect(addLicenseIfRequired(context, owner, repo)).resolves.toBe(
+      undefined
+    );
+  });
+
+  it('Adding a license should fail because add file failed', async () => {
+    const aRepoScheduleEvent = JSON.parse(JSON.stringify(repoScheduleEvent));
+    aRepoScheduleEvent.payload.repository.license = null;
+
+    context = new Context(aRepoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true);
+    // @ts-ignore
+    hasPullRequestWithTitle.mockReturnValueOnce(false);
+    // @ts-ignore
+    addFileViaPullRequest.mockImplementation(() => {
+      throw new Error();
     });
 
-    afterEach(() => {
-        jest.clearAllMocks();
-        jest.resetAllMocks();
+    await expect(addLicenseIfRequired(context, owner, repo)).rejects.toThrow();
+  });
+
+  it('Adding a compliance file should resolve', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.installation.account.login;
+    const repo = context.payload.repository.name;
+
+    await expect(
+      addSecurityComplianceInfoIfRequired(context, owner, repo)
+    ).resolves.toBe(undefined);
+  });
+
+  it('Adding a compliance file should fail because ref missing', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.installation.account.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(false);
+
+    await expect(
+      addSecurityComplianceInfoIfRequired(context, owner, repo)
+    ).resolves.toBe(undefined);
+  });
+
+  it('Adding a compliance file should fail because pr exists', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.installation.account.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true);
+    // @ts-ignore
+    hasPullRequestWithTitle.mockReturnValueOnce(true);
+
+    await expect(
+      addSecurityComplianceInfoIfRequired(context, owner, repo)
+    ).resolves.toBe(undefined);
+  });
+
+  it('Adding a compliance file should fail because add file failed', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = context.payload.installation.account.login;
+    const repo = context.payload.repository.name;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true);
+    // @ts-ignore
+    hasPullRequestWithTitle.mockReturnValueOnce(false);
+    // @ts-ignore
+    addFileViaPullRequest.mockImplementation(() => {
+      throw new Error();
+    });
+    // @ts-ignore
+    loadTemplate.mockReturnValue('bla [TODAY] bla');
+
+    await expect(
+      addSecurityComplianceInfoIfRequired(context, owner, repo)
+    ).rejects.toThrow();
+  });
+
+  it('Updating a compliance file should succeed', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+
+    doc.spec.forEach((s) => {
+      s.status = 'exempt';
     });
 
-    it('Adding a license should resolve', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.repository.owner.login;
-        const repo = context.payload.repository.name;
+    const myComplianceResponse = JSON.parse(JSON.stringify(complianceResponse));
+    const content = Buffer.from(yaml.safeDump(doc)).toString('base64');
 
-        // @ts-ignore
-        addFileViaPullRequest.mockImplementation(() =>
-            Promise.resolve());
-        await expect(addLicenseIfRequired(context, owner, repo)).resolves.toBe(undefined);
+    myComplianceResponse.data.content = content;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    // @ts-ignore
+    fetchFileContent.mockReturnValueOnce(myComplianceResponse.data);
+    // @ts-ignore
+    loadTemplate.mockReturnValueOnce('bla [TODAY] bla');
+
+    await fixDeprecatedComplianceStatus(context, owner, repo);
+
+    expect(checkIfRefExists).toBeCalledTimes(2);
+    expect(fetchFileContent).toBeCalled();
+    expect(loadTemplate).toBeCalled();
+    expect(addFileViaPullRequest).toBeCalled();
+  });
+
+  it('Valid compliance status should not be updated', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+
+    const aDoc = yaml.safeLoad(yaml.safeDump(doc));
+    aDoc.spec.forEach((s) => {
+      s.status = 'completed';
     });
 
-    it('Adding a license should fail because ref missing', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.repository.owner.login;
-        const repo = context.payload.repository.name;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(false);
-        await expect(addLicenseIfRequired(context, owner, repo)).resolves.toBe(undefined);
-    });
-
-    it('Adding a license should fail because pr exists', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.repository.owner.login;
-        const repo = context.payload.repository.name;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true);
-        // @ts-ignore
-        hasPullRequestWithTitle.mockReturnValueOnce(true);
-        await expect(addLicenseIfRequired(context, owner, repo)).resolves.toBe(undefined);
-    });
-
-    it('Adding a license should fail because add file failed', async () => {
-        const aRepoScheduleEvent = JSON.parse(JSON.stringify(repoScheduleEvent));
-        aRepoScheduleEvent.payload.repository.license = null;
-
-        context = new Context(aRepoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.repository.owner.login;
-        const repo = context.payload.repository.name;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true);
-        // @ts-ignore
-        hasPullRequestWithTitle.mockReturnValueOnce(false);
-        // @ts-ignore
-        addFileViaPullRequest.mockImplementation(() => {
-            throw new Error();
-        });
-
-        await expect(addLicenseIfRequired(context, owner, repo)).rejects.toThrow();
-    });
-
-    it('Adding a compliance file should resolve', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.installation.account.login;
-        const repo = context.payload.repository.name;
-
-        await expect(addSecurityComplianceInfoIfRequired(context, owner, repo)).resolves.toBe(undefined);
-    });
-
-    it('Adding a compliance file should fail because ref missing', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.installation.account.login;
-        const repo = context.payload.repository.name;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(false);
-
-        await expect(addSecurityComplianceInfoIfRequired(context, owner, repo)).resolves.toBe(undefined);
-    });
-
-    it('Adding a compliance file should fail because pr exists', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.installation.account.login;
-        const repo = context.payload.repository.name;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true);
-        // @ts-ignore
-        hasPullRequestWithTitle.mockReturnValueOnce(true);
-
-        await expect(addSecurityComplianceInfoIfRequired(context, owner, repo)).resolves.toBe(undefined);
-    });
-
-    it('Adding a compliance file should fail because add file failed', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = context.payload.installation.account.login;
-        const repo = context.payload.repository.name;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true);
-        // @ts-ignore
-        hasPullRequestWithTitle.mockReturnValueOnce(false);
-        // @ts-ignore
-        addFileViaPullRequest.mockImplementation(() => {
-            throw new Error();
-        });
-        // @ts-ignore
-        loadTemplate.mockReturnValue('bla [TODAY] bla');
-
-        await expect(addSecurityComplianceInfoIfRequired(context, owner, repo)).rejects.toThrow();
-    });
-
-    it('Updating a compliance file should succeed', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-
-        doc.spec.forEach(s => {
-            s.status = 'exempt';
-        });
-
-        const myComplianceResponse = JSON.parse(JSON.stringify(complianceResponse));
-        const content = Buffer.from(yaml.safeDump(doc)).toString('base64');
-
-        myComplianceResponse.data.content = content;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true).mockReturnValueOnce(false);
-        // @ts-ignore
-        fetchFileContent.mockReturnValueOnce(myComplianceResponse.data)
-        // @ts-ignore
-        loadTemplate.mockReturnValueOnce('bla [TODAY] bla');
-
-        await fixDeprecatedComplianceStatus(context, owner, repo);
-
-        expect(checkIfRefExists).toBeCalledTimes(2);
-        expect(fetchFileContent).toBeCalled();
-        expect(loadTemplate).toBeCalled();
-        expect(addFileViaPullRequest).toBeCalled();
-    });
-
-    it('Valid compliance status should not be updated', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-
-        const aDoc = yaml.safeLoad(yaml.safeDump(doc));
-        aDoc.spec.forEach(s => {
-            s.status = 'completed';
-        });
-
-        const myComplianceResponse = JSON.parse(JSON.stringify(complianceResponse));
-        const content = Buffer.from(yaml.safeDump(aDoc)).toString('base64');
-
-        myComplianceResponse.data.content = content;
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true).mockReturnValueOnce(false);
-        // @ts-ignore
-        fetchFileContent.mockReturnValueOnce(myComplianceResponse.data)
-        // @ts-ignore
-        loadTemplate.mockReturnValueOnce('bla [TODAY] bla');
-
-        await fixDeprecatedComplianceStatus(context, owner, repo);
-
-        expect(checkIfRefExists).toBeCalledTimes(2);
-        expect(fetchFileContent).toBeCalled();
-        expect(loadTemplate).not.toBeCalled();
-        expect(addFileViaPullRequest).not.toBeCalled();
-    });
-
-    it('Repos without a master branch should fail', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(false);
-
-        await fixDeprecatedComplianceStatus(context, owner, repo);
-
-        expect(checkIfRefExists).toBeCalledTimes(1);
-        expect(fetchFileContent).not.toBeCalled();
-        expect(loadTemplate).not.toBeCalled();
-        expect(addFileViaPullRequest).not.toBeCalled();
-    });
-
-    it('Repos with a fix branch already should not be updated', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-
-        // @ts-ignore
-        checkIfRefExists.mockReturnValueOnce(true).mockReturnValueOnce(true);
-
-        await fixDeprecatedComplianceStatus(context, owner, repo);
-
-        expect(checkIfRefExists).toBeCalledTimes(2);
-        expect(fetchFileContent).not.toBeCalled();
-        expect(loadTemplate).not.toBeCalled();
-        expect(addFileViaPullRequest).not.toBeCalled();
-    });
-
-    it('Repo with valid topics is ignored', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-        const aTopicsResponse = JSON.parse(JSON.stringify(repoGetTopics));
-        aTopicsResponse.data.names = ['CITZ'];
-
-        github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
-        github.repos.listTopics.mockReturnValueOnce(Promise.resolve(aTopicsResponse));
-
-        await addMinistryTopicIfRequired(context, owner, repo);
-
-        expect(github.repos.listTopics).toBeCalled();
-        expect(github.search.issuesAndPullRequests).not.toBeCalled();
-        expect(loadTemplate).not.toBeCalled();
-        expect(github.issues.create).not.toBeCalled();
-    });
-
-    it('Repo with existing issues is ignored', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-        const aTopicsResponse = JSON.parse(JSON.stringify(repoGetTopics));
-        aTopicsResponse.data.names = ['cat'];
-
-        github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(issuesAndPulls));
-        github.repos.listTopics.mockReturnValueOnce(Promise.resolve(aTopicsResponse));
-
-        await addMinistryTopicIfRequired(context, owner, repo);
-
-        expect(github.repos.listTopics).toBeCalled();
-        expect(github.search.issuesAndPullRequests).toBeCalled();
-        expect(loadTemplate).not.toBeCalled();
-        expect(github.issues.create).not.toBeCalled();
-    });
-
-    it('Repo with not topics or issues is processed', async () => {
-        context = new Context(repoScheduleEvent, github as any, {} as any);
-        const owner = 'bcgov';
-        const repo = 'hello5';
-        const aTopicsResponse = JSON.parse(JSON.stringify(repoGetTopics));
-        aTopicsResponse.data.names = ['cat'];
-        const aRepoResponse = JSON.parse(JSON.stringify(issuesAndPulls));
-        aRepoResponse.data.items = [];
-        aRepoResponse.data.total_count = 0;
-
-        github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(aRepoResponse));
-        github.repos.listTopics.mockReturnValueOnce(Promise.resolve(aTopicsResponse));
-
-        await addMinistryTopicIfRequired(context, owner, repo);
-
-        expect(github.repos.listTopics).toBeCalled();
-        expect(github.search.issuesAndPullRequests).toBeCalled();
-        expect(loadTemplate).toBeCalled();
-        expect(github.issues.create).toBeCalled();
-    });
-
-    it('A Repo with issues disabled is skipped', async () => {
-        const owner = 'bcgov';
-        const repo = 'hello5';
-        const aRepoCreated = JSON.parse(JSON.stringify(repoCreated));
-        aRepoCreated.payload.repository.has_issues = false;
-
-        context = new Context(aRepoCreated, github as any, {} as any);
-
-        // const aRepoResponse = JSON.parse(JSON.stringify(issuesAndPulls));
-        // aRepoResponse.data.items = [];
-        // aRepoResponse.data.total_count = 0;
-
-        // github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(aRepoResponse));
-
-        await addWordsMatterIfRequire(context, owner, repo);
-
-        expect(github.search.issuesAndPullRequests).not.toBeCalled();
-        expect(loadTemplate).not.toBeCalled();
-        expect(github.issues.create).not.toBeCalled();
-    });
-
-    it('A Repo without any issue has words matter issue created', async () => {
-        const owner = 'bcgov';
-        const repo = 'hello5';
-        const aRepoCreated = JSON.parse(JSON.stringify(repoCreated));
-        aRepoCreated.payload.repository.has_issues = true;
-
-        context = new Context(aRepoCreated, github as any, {} as any);
-
-        const aRepoResponse = JSON.parse(JSON.stringify(issuesAndPulls));
-        aRepoResponse.data.items = [];
-        aRepoResponse.data.total_count = 0;
-
-        github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(aRepoResponse));
-
-        await addWordsMatterIfRequire(context, owner, repo);
-
-        expect(github.search.issuesAndPullRequests).toBeCalled();
-        expect(loadTemplate).toBeCalled();
-        expect(github.issues.create).toBeCalled();
-    });
+    const myComplianceResponse = JSON.parse(JSON.stringify(complianceResponse));
+    const content = Buffer.from(yaml.safeDump(aDoc)).toString('base64');
+
+    myComplianceResponse.data.content = content;
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    // @ts-ignore
+    fetchFileContent.mockReturnValueOnce(myComplianceResponse.data);
+    // @ts-ignore
+    loadTemplate.mockReturnValueOnce('bla [TODAY] bla');
+
+    await fixDeprecatedComplianceStatus(context, owner, repo);
+
+    expect(checkIfRefExists).toBeCalledTimes(2);
+    expect(fetchFileContent).toBeCalled();
+    expect(loadTemplate).not.toBeCalled();
+    expect(addFileViaPullRequest).not.toBeCalled();
+  });
+
+  it('Repos without a master branch should fail', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(false);
+
+    await fixDeprecatedComplianceStatus(context, owner, repo);
+
+    expect(checkIfRefExists).toBeCalledTimes(1);
+    expect(fetchFileContent).not.toBeCalled();
+    expect(loadTemplate).not.toBeCalled();
+    expect(addFileViaPullRequest).not.toBeCalled();
+  });
+
+  it('Repos with a fix branch already should not be updated', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+
+    // @ts-ignore
+    checkIfRefExists.mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+    await fixDeprecatedComplianceStatus(context, owner, repo);
+
+    expect(checkIfRefExists).toBeCalledTimes(2);
+    expect(fetchFileContent).not.toBeCalled();
+    expect(loadTemplate).not.toBeCalled();
+    expect(addFileViaPullRequest).not.toBeCalled();
+  });
+
+  it('Repo with valid topics is ignored', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+    const aTopicsResponse = JSON.parse(JSON.stringify(repoGetTopics));
+    aTopicsResponse.data.names = ['CITZ'];
+
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPulls)
+    );
+    github.repos.listTopics.mockReturnValueOnce(
+      Promise.resolve(aTopicsResponse)
+    );
+
+    await addMinistryTopicIfRequired(context, owner, repo);
+
+    expect(github.repos.listTopics).toBeCalled();
+    expect(github.search.issuesAndPullRequests).not.toBeCalled();
+    expect(loadTemplate).not.toBeCalled();
+    expect(github.issues.create).not.toBeCalled();
+  });
+
+  it('Repo with existing issues is ignored', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+    const aTopicsResponse = JSON.parse(JSON.stringify(repoGetTopics));
+    aTopicsResponse.data.names = ['cat'];
+
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(issuesAndPulls)
+    );
+    github.repos.listTopics.mockReturnValueOnce(
+      Promise.resolve(aTopicsResponse)
+    );
+
+    await addMinistryTopicIfRequired(context, owner, repo);
+
+    expect(github.repos.listTopics).toBeCalled();
+    expect(github.search.issuesAndPullRequests).toBeCalled();
+    expect(loadTemplate).not.toBeCalled();
+    expect(github.issues.create).not.toBeCalled();
+  });
+
+  it('Repo with not topics or issues is processed', async () => {
+    context = new Context(repoScheduleEvent, github as any, {} as any);
+    const owner = 'bcgov';
+    const repo = 'hello5';
+    const aTopicsResponse = JSON.parse(JSON.stringify(repoGetTopics));
+    aTopicsResponse.data.names = ['cat'];
+    const aRepoResponse = JSON.parse(JSON.stringify(issuesAndPulls));
+    aRepoResponse.data.items = [];
+    aRepoResponse.data.total_count = 0;
+
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(aRepoResponse)
+    );
+    github.repos.listTopics.mockReturnValueOnce(
+      Promise.resolve(aTopicsResponse)
+    );
+
+    await addMinistryTopicIfRequired(context, owner, repo);
+
+    expect(github.repos.listTopics).toBeCalled();
+    expect(github.search.issuesAndPullRequests).toBeCalled();
+    expect(loadTemplate).toBeCalled();
+    expect(github.issues.create).toBeCalled();
+  });
+
+  it('A Repo with issues disabled is skipped', async () => {
+    const owner = 'bcgov';
+    const repo = 'hello5';
+    const aRepoCreated = JSON.parse(JSON.stringify(repoCreated));
+    aRepoCreated.payload.repository.has_issues = false;
+
+    context = new Context(aRepoCreated, github as any, {} as any);
+
+    // const aRepoResponse = JSON.parse(JSON.stringify(issuesAndPulls));
+    // aRepoResponse.data.items = [];
+    // aRepoResponse.data.total_count = 0;
+
+    // github.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve(aRepoResponse));
+
+    await addWordsMatterIfRequire(context, owner, repo);
+
+    expect(github.search.issuesAndPullRequests).not.toBeCalled();
+    expect(loadTemplate).not.toBeCalled();
+    expect(github.issues.create).not.toBeCalled();
+  });
+
+  it('A Repo without any issue has words matter issue created', async () => {
+    const owner = 'bcgov';
+    const repo = 'hello5';
+    const aRepoCreated = JSON.parse(JSON.stringify(repoCreated));
+    aRepoCreated.payload.repository.has_issues = true;
+
+    context = new Context(aRepoCreated, github as any, {} as any);
+
+    const aRepoResponse = JSON.parse(JSON.stringify(issuesAndPulls));
+    aRepoResponse.data.items = [];
+    aRepoResponse.data.total_count = 0;
+
+    github.search.issuesAndPullRequests.mockReturnValueOnce(
+      Promise.resolve(aRepoResponse)
+    );
+
+    await addWordsMatterIfRequire(context, owner, repo);
+
+    expect(github.search.issuesAndPullRequests).toBeCalled();
+    expect(loadTemplate).toBeCalled();
+    expect(github.issues.create).toBeCalled();
+  });
 });

--- a/__tests__/robo.test.ts
+++ b/__tests__/robo.test.ts
@@ -22,7 +22,12 @@ import path from 'path';
 import { Context } from 'probot';
 import { ISSUE_TITLES } from '../src/constants';
 import { assignUsersToIssue, fetchContentsForFile } from '../src/libs/ghutils';
-import { applyComplianceCommands, handleBotCommand, handleComplianceCommands, helpDeskSupportRequired } from '../src/libs/robo';
+import {
+  applyComplianceCommands,
+  handleBotCommand,
+  handleComplianceCommands,
+  helpDeskSupportRequired,
+} from '../src/libs/robo';
 import helper from './src/helper';
 
 const p0 = path.join(__dirname, 'fixtures/issue_comment-event.json');
@@ -35,141 +40,140 @@ const p2 = path.join(__dirname, 'fixtures/compliance.yaml');
 const doc = yaml.safeLoad(fs.readFileSync(p2, 'utf8'));
 
 jest.mock('../src/libs/ghutils', () => ({
-    assignUsersToIssue: jest.fn(),
-    fetchContentsForFile: jest.fn(),
+  assignUsersToIssue: jest.fn(),
+  fetchContentsForFile: jest.fn(),
 }));
 
 Date.now = jest.fn();
 
 describe('Bot command processing', () => {
-    let context;
-    const { github } = helper;
+  let context;
+  const { github } = helper;
 
-    beforeEach(() => {
-        context = undefined;
-        // @ts-ignore
-        Date.now.mockReturnValue(1576090712480);
+  beforeEach(() => {
+    context = undefined;
+    // @ts-ignore
+    Date.now.mockReturnValue(1576090712480);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('Missing compliance commands are ignored', async () => {
+    const comment = 'hello, I am a teapot';
+    const result = applyComplianceCommands(comment, doc);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Invalid compliance commands are ignored', async () => {
+    const comment = '/change-pia completed';
+    const result = applyComplianceCommands(comment, doc);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Valid compliance commands are processed', async () => {
+    const comment = `@repo-mountie update-pia completed\n@repo-mountie update-stra completed`;
+    const result = applyComplianceCommands(comment, doc);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Help requests issues are processed', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = '@repo-mountie help\n';
+    const result = helpDeskSupportRequired(context.payload);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('Non-help comments are ignored', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = 'I\'m a teapot';
+    const result = helpDeskSupportRequired(context.payload);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('Missing file causes update to be skipped', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = `@repo-mountie update-pia completed`;
+    // @ts-ignore
+    fetchContentsForFile.mockReturnValueOnce(undefined);
+
+    await handleComplianceCommands(context);
+
+    expect(fetchContentsForFile).toBeCalled();
+    expect(github.repos.createOrUpdateFile).not.toBeCalled();
+  });
+
+  it('Invalid command causes update to be skipped', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = `@repo-mountie update-blarb completed`;
+    // @ts-ignore
+    fetchContentsForFile.mockReturnValueOnce(content.data);
+
+    await handleComplianceCommands(context);
+
+    expect(fetchContentsForFile).not.toBeCalled();
+    expect(github.repos.createOrUpdateFile).not.toBeCalled();
+  });
+
+  it('Compliance commands are processed appropriately', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = `@repo-mountie update-pia completed`;
+    // @ts-ignore
+    fetchContentsForFile.mockReturnValueOnce(content.data);
+
+    await handleComplianceCommands(context);
+
+    expect(fetchContentsForFile).toBeCalled();
+    expect(github.repos.createOrUpdateFile).toBeCalled();
+  });
+
+  it('An error is handled correctly', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = `@repo-mountie help`;
+    context.payload.issue.title = ISSUE_TITLES.ADD_COMPLIANCE;
+    context.payload.sender.type = 'User';
+
+    // @ts-ignore
+    assignUsersToIssue.mockImplementationOnce(() => {
+      throw new Error();
     });
 
-    afterEach(() => {
-        jest.clearAllMocks();
-        jest.resetAllMocks();
-    });
+    await expect(handleBotCommand(context)).rejects.toThrow();
+  });
 
-    it('Missing compliance commands are ignored', async () => {
-        const comment = 'hello, I am a teapot';
-        const result = applyComplianceCommands(comment, doc);
-        expect(result).toMatchSnapshot();
-    });
+  it('An unknown PR is disregarded', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = 'I fixed up the code real good.';
+    context.payload.issue.title = 'Fix a bug';
+    // @ts-ignore
+    handleComplianceCommands = jest.fn();
 
-    it('Invalid compliance commands are ignored', async () => {
-        const comment = '/change-pia completed';
-        const result = applyComplianceCommands(comment, doc);
-        expect(result).toMatchSnapshot();
-    });
+    await handleBotCommand(context);
 
-    it('Valid compliance commands are processed', async () => {
-        const comment = `@repo-mountie update-pia completed\n@repo-mountie update-stra completed`;
-        const result = applyComplianceCommands(comment, doc);
-        expect(result).toMatchSnapshot();
-    });
+    expect(handleComplianceCommands).not.toBeCalled();
+  });
 
-    it('Help requests issues are processed', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = '@repo-mountie help\n';
-        const result = helpDeskSupportRequired(context.payload);
+  it('A request for help is processed correctly', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.comment.body = '/help';
+    context.payload.issue.title = ISSUE_TITLES.ADD_COMPLIANCE;
+    // @ts-ignore
+    assignUsersToIssue.mockReturnValueOnce();
 
-        expect(result).toBeTruthy();
-    });
+    await expect(handleBotCommand(context)).resolves.toBeUndefined();
+  });
 
-    it('Non-help comments are ignored', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = 'I\'m a teapot';
-        const result = helpDeskSupportRequired(context.payload);
+  it('A ', async () => {
+    context = new Context(issueCommentEvent, github as any, {} as any);
+    context.payload.issue.title = ISSUE_TITLES.ADD_COMPLIANCE;
+    // @ts-ignore
 
-        expect(result).toBeFalsy();
-    });
+    await handleBotCommand(context);
 
-    it('Missing file causes update to be skipped', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = `@repo-mountie update-pia completed`;
-        // @ts-ignore
-        fetchContentsForFile.mockReturnValueOnce(undefined);
-
-        await handleComplianceCommands(context);
-
-        expect(fetchContentsForFile).toBeCalled();
-        expect(github.repos.createOrUpdateFile).not.toBeCalled();
-    });
-
-
-    it('Invalid command causes update to be skipped', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = `@repo-mountie update-blarb completed`;
-        // @ts-ignore
-        fetchContentsForFile.mockReturnValueOnce(content.data);
-
-        await handleComplianceCommands(context);
-
-        expect(fetchContentsForFile).not.toBeCalled();
-        expect(github.repos.createOrUpdateFile).not.toBeCalled();
-    });
-
-    it('Compliance commands are processed appropriately', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = `@repo-mountie update-pia completed`;
-        // @ts-ignore
-        fetchContentsForFile.mockReturnValueOnce(content.data);
-
-        await handleComplianceCommands(context);
-
-        expect(fetchContentsForFile).toBeCalled();
-        expect(github.repos.createOrUpdateFile).toBeCalled();
-    });
-
-    it('An error is handled correctly', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = `@repo-mountie help`;
-        context.payload.issue.title = ISSUE_TITLES.ADD_COMPLIANCE;
-        context.payload.sender.type = 'User';
-
-        // @ts-ignore
-        assignUsersToIssue.mockImplementationOnce(() => {
-            throw new Error();
-        });
-
-        await expect(handleBotCommand(context)).rejects.toThrow();
-    });
-
-    it('An unknown PR is disregarded', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = 'I fixed up the code real good.';
-        context.payload.issue.title = 'Fix a bug';
-        // @ts-ignore
-        handleComplianceCommands = jest.fn();
-
-        await handleBotCommand(context);
-
-        expect(handleComplianceCommands).not.toBeCalled();
-    });
-
-    it('A request for help is processed correctly', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.comment.body = '/help';
-        context.payload.issue.title = ISSUE_TITLES.ADD_COMPLIANCE;
-        // @ts-ignore
-        assignUsersToIssue.mockReturnValueOnce();
-
-        await expect(handleBotCommand(context)).resolves.toBeUndefined();
-    });
-
-    it('A ', async () => {
-        context = new Context(issueCommentEvent, github as any, {} as any);
-        context.payload.issue.title = ISSUE_TITLES.ADD_COMPLIANCE;
-        // @ts-ignore
-
-        await handleBotCommand(context);
-
-        expect(handleComplianceCommands).toBeCalled();
-    });
+    expect(handleComplianceCommands).toBeCalled();
+  });
 });

--- a/__tests__/routes.test.ts
+++ b/__tests__/routes.test.ts
@@ -21,8 +21,6 @@ import app from '../src';
 
 describe('Test monitoring routes', () => {
   it.skip('The readiness probe should respond with 200 ', async () => {
-    await request(app)
-      .get('/ehlo')
-      .expect(200);
+    await request(app).get('/ehlo').expect(200);
   });
 });

--- a/__tests__/src/helper.ts
+++ b/__tests__/src/helper.ts
@@ -16,8 +16,6 @@
 // Created by Jason Leach on 2020-02-26.
 //
 
-
-
 // nock('https://api.github.com')
 //     .get('/app/installations')
 //     .query({ per_page: 100 })
@@ -31,56 +29,56 @@
 let github;
 
 github = {
-    paginate: jest.fn().mockReturnValue([]),
-    apps: {
-        listRepos: {
-            endpoint: {
-                merge: jest.fn(),
-            },
-        },
+  paginate: jest.fn().mockReturnValue([]),
+  apps: {
+    listRepos: {
+      endpoint: {
+        merge: jest.fn(),
+      },
     },
-    git: {
-        createRef: jest.fn(),
-        getRef: jest.fn(),
-    },
-    gitdata: {
-        createRef: jest.fn(),
-        getRef: jest.fn(),
-    },
-    issues: {
-        addAssignees: jest.fn(),
-        addLabels: jest.fn(),
-        createComment: jest.fn(),
-        listLabelsForRepo: jest.fn(),
-        update: jest.fn(),
-        create: jest.fn(),
-    },
-    orgs: {
-        checkMembership: jest.fn(),
-    },
-    pullRequests: {
-        create: jest.fn(),
-        getAll: jest.fn(),
-        list: jest.fn(),
-    },
-    pulls: {
-        create: jest.fn(),
-        getAll: jest.fn(),
-        list: jest.fn(),
-    },
-    repos: {
-        createFile: jest.fn(),
-        createOrUpdateFile: jest.fn(),
-        getContents: jest.fn(),
-        listCollaborators: jest.fn(),
-        listCommits: jest.fn(),
-        listTopics: jest.fn(),
-    },
-    search: {
-        issuesAndPullRequests: jest.fn(),
-    },
+  },
+  git: {
+    createRef: jest.fn(),
+    getRef: jest.fn(),
+  },
+  gitdata: {
+    createRef: jest.fn(),
+    getRef: jest.fn(),
+  },
+  issues: {
+    addAssignees: jest.fn(),
+    addLabels: jest.fn(),
+    createComment: jest.fn(),
+    listLabelsForRepo: jest.fn(),
+    update: jest.fn(),
+    create: jest.fn(),
+  },
+  orgs: {
+    checkMembership: jest.fn(),
+  },
+  pullRequests: {
+    create: jest.fn(),
+    getAll: jest.fn(),
+    list: jest.fn(),
+  },
+  pulls: {
+    create: jest.fn(),
+    getAll: jest.fn(),
+    list: jest.fn(),
+  },
+  repos: {
+    createFile: jest.fn(),
+    createOrUpdateFile: jest.fn(),
+    getContents: jest.fn(),
+    listCollaborators: jest.fn(),
+    listCommits: jest.fn(),
+    listTopics: jest.fn(),
+  },
+  search: {
+    issuesAndPullRequests: jest.fn(),
+  },
 };
 
 export default {
-    github,
+  github,
 };

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -18,11 +18,9 @@
 
 import { extractMessage, isJSON, loadTemplate } from '../src/libs/utils';
 
-
 jest.mock('fs');
 
 describe('Utility functions', () => {
-
   afterEach(() => {
     jest.clearAllMocks();
     jest.resetAllMocks();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12939,9 +12939,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.2.tgz",
-      "integrity": "sha512-UyNrLdK3E0fQG/xWNqAFAC5ugtFyPO4JJR1KyyfQAyzR8W0fTRrC91A8Wej4BntFzcvETdCSDa/4PnNYJQLYiA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -12955,7 +12955,7 @@
         "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.10.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {
@@ -13014,6 +13014,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "supertest": "^4.0.2",
     "ts-jest": "^26.1.1",
     "ts-node": "^8.10.2",
-    "tslint": "^6.1.2",
+    "tslint": "^6.1.3",
     "tslint-config-airbnb": "^5.11.1",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.6",
@@ -69,6 +69,10 @@
     "./src/**/*.ts": [
       "npx prettier ./src/**/*.ts --write",
       "tslint ./src/**/*.ts --fix"
+    ],
+    "./__tests__/**/*.ts": [
+      "npx prettier ./__tests__/**/*.ts --write",
+      "tslint ./__tests__/**/*.ts --fix"
     ]
   },
   "engines": {


### PR DESCRIPTION
tslint and eslint do not have the same configuration properties. Switching to eslint would mean the entire codebase would need to be changed in order to adhere to the new eslint config. 

tslint correctly lints test files. eslint-typescript-support and eslint-plugin-jest are not needed. 

Fixes issue #117 