### PR TITLE
Disabled lifecycle badge function

### DIFF
--- a/src/libs/handlers.ts
+++ b/src/libs/handlers.ts
@@ -27,14 +27,13 @@ import { checkForStaleIssues, created } from './issue';
 import {
   addCollaboratorsToMyIssues,
   requestUpdateForMyIssues,
-  validatePullRequestIfRequired,
+  validatePullRequestIfRequired
 } from './pullrequest';
 import {
   addLicenseIfRequired,
   addMinistryTopicIfRequired,
   addSecurityComplianceInfoIfRequired,
-  addWordsMatterIfRequire,
-  requestLifecycleBadgeIfRequired,
+  addWordsMatterIfRequire
 } from './repository';
 
 export const memberAddedOrEdited = async (context: Context): Promise<void> => {
@@ -154,7 +153,7 @@ export const repositoryScheduled = async (
       addSecurityComplianceInfoIfRequired(context, owner, repo),
       addCollaboratorsToMyIssues(context, owner, repo),
       requestUpdateForMyIssues(context, owner, repo),
-      requestLifecycleBadgeIfRequired(context, owner, repo),
+      // requestLifecycleBadgeIfRequired(context, owner, repo),
     ]);
   } catch (err) {
     const message = `Unable to complete all housekeeping tasks, repo is ${repo}`;

--- a/src/libs/handlers.ts
+++ b/src/libs/handlers.ts
@@ -27,13 +27,13 @@ import { checkForStaleIssues, created } from './issue';
 import {
   addCollaboratorsToMyIssues,
   requestUpdateForMyIssues,
-  validatePullRequestIfRequired
+  validatePullRequestIfRequired,
 } from './pullrequest';
 import {
   addLicenseIfRequired,
   addMinistryTopicIfRequired,
   addSecurityComplianceInfoIfRequired,
-  addWordsMatterIfRequire
+  addWordsMatterIfRequire,
 } from './repository';
 
 export const memberAddedOrEdited = async (context: Context): Promise<void> => {


### PR DESCRIPTION
There is a bug with the function requestLifecycleBadgeIfRequired. 
Commenting out the entrypoint logic so the bot can run without the function