### PR TITLE
Fix/lifecycle badge

### DIFF
--- a/__tests__/fixtures/repo-get-content-readme.json
+++ b/__tests__/fixtures/repo-get-content-readme.json
@@ -9,7 +9,7 @@
     "git_url": "https://api.github.com/repos/bcgov/glarb/git/blobs/fc5f44d45e03b298219083b201db858f7a06aa1d",
     "download_url": "https://raw.githubusercontent.com/bcgov/glarb/master/rmconfig.json",
     "type": "file",
-    "content": "Here's an invalid project badge. ![img](https://img.shields.io/badge/Lifecycle-Testing-007EC6)",
+    "content": "SGVyZSdzIGFuIGludmFsaWQgcHJvamVjdCBiYWRnZS4gIVtpbWddKGh0dHBzOi8vaW1nLnNoaWVsZHMuaW8vYmFkZ2UvTGlmZWN5Y2xlLVRlc3RpbmctMDA3RUM2KQ",
     "encoding": "base64",
     "_links": {
       "self": "https://api.github.com/repos/bcgov/glarb/contents/rmconfig.json?ref=master",

--- a/__tests__/fixtures/repo-get-content-readme.json
+++ b/__tests__/fixtures/repo-get-content-readme.json
@@ -9,7 +9,7 @@
     "git_url": "https://api.github.com/repos/bcgov/glarb/git/blobs/fc5f44d45e03b298219083b201db858f7a06aa1d",
     "download_url": "https://raw.githubusercontent.com/bcgov/glarb/master/rmconfig.json",
     "type": "file",
-    "content": "SGVyZSdzIGFuIGludmFsaWQgcHJvamVjdCBiYWRnZS4gIVtpbWddKGh0dHBzOi8vaW1nLnNoaWVsZHMuaW8vYmFkZ2UvTGlmZWN5Y2xlLVRlc3RpbmctMDA3RUM2KQ",
+    "content": "SGVyZSdzIGFuIGludmFsaWQgcHJvamVjdCBiYWRnZS4gIVtpbWddKGh0dHBzOi8vaW1nLnNoaWVsZHMuaW8vYmFkZ2UvSW52YWxpZC1CYWRnZS0wMDdFQzYp",
     "encoding": "base64",
     "_links": {
       "self": "https://api.github.com/repos/bcgov/glarb/contents/rmconfig.json?ref=master",

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -426,7 +426,7 @@ describe('Repository management', () => {
 
     // tslint:disable
     const contentString =
-      "Here's a valid project badge. [![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)";
+      "Here's a valid project badge. ![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)";
     // tslint:enable
     const encodedContent = Buffer.from(contentString).toString('base64');
 
@@ -451,7 +451,7 @@ describe('Repository management', () => {
     const repo = context.payload.repository.name;
 
     // readmeResponse.data.content is the base64 encoded of:
-    // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Lifecycle-Testing-007EC6)"
+    // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Invalid-Badge-007EC6)"
     // @ts-ignore
     fetchFileContent.mockReturnValueOnce(Promise.resolve(readmeResponse.data));
 
@@ -473,7 +473,7 @@ describe('Repository management', () => {
     const repo = context.payload.repository.name;
 
     // readmeResponse.data.content is the base64 encoded of:
-    // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Lifecycle-Testing-007EC6)"
+    // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Invalid-Badge-007EC6)"
     // @ts-ignore
     fetchFileContent.mockReturnValueOnce(Promise.resolve(readmeResponse.data));
 
@@ -517,19 +517,19 @@ describe('doesContentHaveLifecycleBadge', () => {
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
+        "[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)]()"
       )
     ).toBe(true);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
+        "[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)]"
       )
     ).toBe(true);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
+        "[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/)"
       )
     ).toBe(true);
     expect(
@@ -539,17 +539,18 @@ describe('doesContentHaveLifecycleBadge', () => {
       )
     ).toBe(true);
   });
+
   it('Invalid lifecycle badges should return false', () => {
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)"
+        "![img](https://img.shields.io/badge/Invalid-Badge-339999)"
       )
     ).toBe(false);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Invalid-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
+        "[![img](https://img.shields.io/badge/Invalid-Badge-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
       )
     ).toBe(false);
   });

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -511,31 +511,31 @@ describe('doesContentHaveLifecycleBadge', () => {
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
+        "[![](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
       )
     ).toBe(true);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)]()"
+        "![](https://img.shields.io/badge/Lifecycle-Stable-97ca00)"
       )
     ).toBe(true);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)]"
+        "[![lifecycle:stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)]"
       )
     ).toBe(true);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/)"
+        "[![lifecycle:dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/)"
       )
     ).toBe(true);
     expect(
       doesContentHaveLifecycleBadge(
         // tslint:disable-next-line
-        "[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
+        "[![random-text](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)"
       )
     ).toBe(true);
   });

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -423,8 +423,14 @@ describe('Repository management', () => {
     const repo = context.payload.repository.name;
 
     const myReadmeResponse = JSON.parse(JSON.stringify(readmeResponse));
-    // tslint:disable-next-line
-    myReadmeResponse.data.content = `Here's a valid project badge. [![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)`;
+
+    // tslint:disable
+    const contentString =
+      "Here's a valid project badge. [![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)";
+    // tslint:enable
+    const encodedContent = Buffer.from(contentString).toString('base64');
+
+    myReadmeResponse.data.content = encodedContent;
     // @ts-ignore
     fetchFileContent.mockReturnValueOnce(
       Promise.resolve(myReadmeResponse.data)
@@ -444,6 +450,8 @@ describe('Repository management', () => {
     const owner = context.payload.installation.account.login;
     const repo = context.payload.repository.name;
 
+    // readmeResponse.data.content is the base64 encoded of:
+    // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Lifecycle-Testing-007EC6)"
     // @ts-ignore
     fetchFileContent.mockReturnValueOnce(Promise.resolve(readmeResponse.data));
 
@@ -464,6 +472,8 @@ describe('Repository management', () => {
     const owner = context.payload.installation.account.login;
     const repo = context.payload.repository.name;
 
+    // readmeResponse.data.content is the base64 encoded of:
+    // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Lifecycle-Testing-007EC6)"
     // @ts-ignore
     fetchFileContent.mockReturnValueOnce(Promise.resolve(readmeResponse.data));
     github.search.issuesAndPullRequests.mockReturnValueOnce(

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -476,9 +476,11 @@ describe('Repository management', () => {
     // "Here's an invalid project badge. ![img](https://img.shields.io/badge/Lifecycle-Testing-007EC6)"
     // @ts-ignore
     fetchFileContent.mockReturnValueOnce(Promise.resolve(readmeResponse.data));
+
     github.search.issuesAndPullRequests.mockReturnValueOnce(
       Promise.resolve(issuesAndPullsEmpty)
     );
+
     await requestLifecycleBadgeIfRequired(context, owner, repo);
 
     expect(fetchFileContent).toBeCalled();

--- a/doc/lifecycle-badges.md
+++ b/doc/lifecycle-badges.md
@@ -6,21 +6,21 @@ A project lifecycle badge should be included in the readme and will indicate wha
 
 Repo-mountie will only recognize project lifecycle badges if they are used with the **provided image URLs**. Please use the URLs provided, **not** the images.
 
-[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)```\
+[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](<Redirect-URL>)```\
 The project is in the very early stages of development. The codebase will be changing frequently.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)```\
+[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](<Redirect-URL>)```\
 The codebase is being roughed out, but finer details are likely to change.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)```\
+[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](<Redirect-URL>)```\
 The project is in a reliable state and major changes are unlikely to happen.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)```\
+[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](<Redirect-URL>)```\
 The project is currently not under active development, but there are plans to redevelop.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)```\
+[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](<Redirect-URL>)```\
 The project is no longer being used and/or supported.

--- a/doc/lifecycle-badges.md
+++ b/doc/lifecycle-badges.md
@@ -6,21 +6,21 @@ A project lifecycle badge should be included in the readme and will indicate wha
 
 Repo-mountie will only recognize project lifecycle badges if they are used with the **provided image URLs**. Please use the URLs provided, **not** the images.
 
-[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Experimental-339999)](<Redirect-URL>)```\
+[![Lifecycle:Experimental](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![Lifecycle:Experimental](https://img.shields.io/badge/Lifecycle-Experimental-339999)](<Redirect-URL>)```\
 The project is in the very early stages of development. The codebase will be changing frequently.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](<Redirect-URL>)```\
+[![Lifecycle:Maturing](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![Lifecycle:Maturing](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](<Redirect-URL>)```\
 The codebase is being roughed out, but finer details are likely to change.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](<Redirect-URL>)```\
+[![Lifecycle:Stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![Lifecycle:Stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](<Redirect-URL>)```\
 The project is in a reliable state and major changes are unlikely to happen.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](<Redirect-URL>)```\
+[![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](<Redirect-URL>)```\
 The project is currently not under active development, but there are plans to redevelop.
 
 
-[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![img](https://img.shields.io/badge/Lifecycle-Retired-d45500)](<Redirect-URL>)```\
+[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md) - ```[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](<Redirect-URL>)```\
 The project is no longer being used and/or supported.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "NODE_ENV=production gulp",
     "dev": "nodemon --watch src --inspect=5858 -e ts,tsx --exec node -r ts-node/register ./src/main.ts",
-    "start": "probot run ./build/src/index.js",
+    "start": "probot run ./build/index.js",
     "report": "ts-node scripts/report.ts",
     "test:lint": "NODE_ENV=test tslint src/**/*.ts",
     "test": "NODE_ENV=test jest __tests__",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "NODE_ENV=production gulp",
     "dev": "nodemon --watch src --inspect=5858 -e ts,tsx --exec node -r ts-node/register ./src/main.ts",
-    "start": "probot run ./build/index.js",
+    "start": "probot run ./build/src/index.js",
     "report": "ts-node scripts/report.ts",
     "test:lint": "NODE_ENV=test tslint src/**/*.ts",
     "test": "NODE_ENV=test jest __tests__",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,11 +16,11 @@
 // Created by Jason Leach on 2018-10-01.
 //
 
-export const SCHEDULER_DELAY: number = 24 * 60 * 60 * 1000; // one day
+export const SCHEDULER_DELAY: number = 60 * 1000; // one day
 
 export const COMMENT_TRIGGER_WORD = 'help';
 
-export const BOT_NAME = 'repo-mountie';
+export const BOT_NAME = 'repomountie-test2';
 
 export const REPO_CONFIG_FILE = 'rmconfig.json';
 
@@ -98,7 +98,7 @@ export const REGEXP = {
 };
 
 export const ACCESS_CONTROL = {
-  allowedInstallations: ['bcgov', 'fullboar'],
+  allowedInstallations: ['bcgov', 'fullboar', 'test-repomountie-aj'],
   allowedSsoClients: ['reggie-api'],
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,11 +16,11 @@
 // Created by Jason Leach on 2018-10-01.
 //
 
-export const SCHEDULER_DELAY: number = 60 * 1000; // one day
+export const SCHEDULER_DELAY: number = 24 * 60 * 60 * 1000; // one day
 
 export const COMMENT_TRIGGER_WORD = 'help';
 
-export const BOT_NAME = 'repomountie-test2';
+export const BOT_NAME = 'repo-mountie';
 
 export const REPO_CONFIG_FILE = 'rmconfig.json';
 
@@ -98,7 +98,7 @@ export const REGEXP = {
 };
 
 export const ACCESS_CONTROL = {
-  allowedInstallations: ['bcgov', 'fullboar', 'test-repomountie-aj'],
+  allowedInstallations: ['bcgov', 'fullboar'],
   allowedSsoClients: ['reggie-api'],
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,7 +94,7 @@ export const REGEXP = {
   help: '@repo-mountie\\s+help',
   // prettier-ignore
   // tslint:disable-next-line
-  lifecycle_badge: '!\\[img\\]\\(https:\\/\\/img\\.shields\\.io\\/badge\\/Lifecycle-(Maturing-007EC6|Experimental-339999|Stable-97ca00|Dormant-ff7f2a|Retired-d45500)\\)',
+  lifecycle_badge: '!\\[.*\\]\\(https:\\/\\/img\\.shields\\.io\\/badge\\/Lifecycle-(Maturing-007EC6|Experimental-339999|Stable-97ca00|Dormant-ff7f2a|Retired-d45500)\\)',
 };
 
 export const ACCESS_CONTROL = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,7 +94,7 @@ export const REGEXP = {
   help: '@repo-mountie\\s+help',
   // prettier-ignore
   // tslint:disable-next-line
-  lifecycle_badge: '\\[\\!\\[img\\]\\(https://img\\.shields\\.io/badge/Lifecycle-(Maturing-007EC6|Experimental-339999|Stable-97ca00|Dormant-ff7f2a|Retired-d45500)\\)\\]\\(https://github\\.com/bcgov/repomountie/blob/master/doc/lifecycle-badges\\.md\\)',
+  lifecycle_badge: '!\\[img\\]\\(https:\\/\\/img\\.shields\\.io\\/badge\\/Lifecycle-(Maturing-007EC6|Experimental-339999|Stable-97ca00|Dormant-ff7f2a|Retired-d45500)\\)',
 };
 
 export const ACCESS_CONTROL = {

--- a/src/libs/handlers.ts
+++ b/src/libs/handlers.ts
@@ -34,6 +34,7 @@ import {
   addMinistryTopicIfRequired,
   addSecurityComplianceInfoIfRequired,
   addWordsMatterIfRequire,
+  requestLifecycleBadgeIfRequired,
 } from './repository';
 
 export const memberAddedOrEdited = async (context: Context): Promise<void> => {
@@ -153,7 +154,7 @@ export const repositoryScheduled = async (
       addSecurityComplianceInfoIfRequired(context, owner, repo),
       addCollaboratorsToMyIssues(context, owner, repo),
       requestUpdateForMyIssues(context, owner, repo),
-      // requestLifecycleBadgeIfRequired(context, owner, repo),
+      requestLifecycleBadgeIfRequired(context, owner, repo),
     ]);
   } catch (err) {
     const message = `Unable to complete all housekeeping tasks, repo is ${repo}`;

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -390,7 +390,6 @@ export const requestLifecycleBadgeIfRequired = async (
   repo: string
 ) => {
   try {
-    // readmeData is base64 encoded
     const readmeData = await fetchFileContent(context, REPO_README);
 
     if (!readmeData) {
@@ -400,6 +399,7 @@ export const requestLifecycleBadgeIfRequired = async (
       return;
     }
 
+    // readmeData.content is base64 encoded
     const decodedContent = Buffer.from(readmeData.content, 'base64').toString();
 
     // Check if README has project badges

--- a/src/libs/repository.ts
+++ b/src/libs/repository.ts
@@ -390,6 +390,7 @@ export const requestLifecycleBadgeIfRequired = async (
   repo: string
 ) => {
   try {
+    // readmeData is base64 encoded
     const readmeData = await fetchFileContent(context, REPO_README);
 
     if (!readmeData) {
@@ -399,8 +400,10 @@ export const requestLifecycleBadgeIfRequired = async (
       return;
     }
 
+    const decodedContent = Buffer.from(readmeData.content, 'base64').toString();
+
     // Check if README has project badges
-    const re = doesContentHaveLifecycleBadge(readmeData.content);
+    const re = doesContentHaveLifecycleBadge(decodedContent);
     if (re) {
       return;
     }


### PR DESCRIPTION
## Summary
The lifecycle badge feature created an issue in users' repos regardless of an existing lifecycle badge in their readme.

The problem was that fetchFileContent function returns data containing the readme content as base64 encoded which caused the regex to fail every time.

The requestLifecycleBadgeIfRequired function is updated to decode the data before performing the regex check.

Resolves https://github.com/bcgov/repomountie/issues/123