### PR TITLE
Loosen up REGEX for Lifecycle badge check [Issue #135]

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,7 +94,7 @@ export const REGEXP = {
   help: '@repo-mountie\\s+help',
   // prettier-ignore
   // tslint:disable-next-line
-  lifecycle_badge: '!\\[.*\\]\\(https:\\/\\/img\\.shields\\.io\\/badge\\/Lifecycle-(Maturing-007EC6|Experimental-339999|Stable-97ca00|Dormant-ff7f2a|Retired-d45500)\\)',
+  lifecycle_badge: '\\[!\\[Lifecycle\\].*\\]',
 };
 
 export const ACCESS_CONTROL = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,7 +94,7 @@ export const REGEXP = {
   help: '@repo-mountie\\s+help',
   // prettier-ignore
   // tslint:disable-next-line
-  lifecycle_badge: '\\[!\\[Lifecycle\\].*\\]',
+  lifecycle_badge: '\\[!\\[(Lifecycle\\].*\\]|\\(.*lifecycle-badges.md\\))',
 };
 
 export const ACCESS_CONTROL = {


### PR DESCRIPTION
Addresses the regex portion of #135 for being issue-spammed by @repomountie in multiple repos.

Adds support for detecting badges with styling or reference-style links.  Matches a badge named Lifecycle instead of an exact badge URL (e.g. https://img.shields.io/badge/Lifecycle-Stable-97ca00).  Can also match links ending in `lifecycle-badges.md)`.

E.g. Match `[![Lifecycle][reference-link].*` or `[![Lifecycle](.*?style=for-the-badge)]`
E.g. Match `[![notLifecycle].*lifecycle-badges.md)`
