### PR TITLE
Add snapshot test for created issue template

### DIFF
--- a/__tests__/__snapshots__/templates.test.ts.snap
+++ b/__tests__/__snapshots__/templates.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Template Snapshots Loads the expected template for inactive repository issues 1`] = `
-"This issue is a kind reminder that your repository has been inactive for 1 days. Some repositories are maintained in accordance with business requirements that infrequently change thus appearing inactive, and some repositories are inactive because they are unmaintained.
+"This issue is a kind reminder that your repository has been inactive for 14 days. Some repositories are maintained in accordance with business requirements that infrequently change thus appearing inactive, and some repositories are inactive because they are unmaintained.
 
-To help differentiate products that are unmaintained from products that do not require frequent maintenance, repomountie will open an issue whenever a repository has not been updated in 2 days.
+To help differentiate products that are unmaintained from products that do not require frequent maintenance, repomountie will open an issue whenever a repository has not been updated in 7 days.
 
 - If this product is being actively maintained, please close this issue.
 - If this repository isn't being actively maintained anymore, please archive this repository. Also, for bonus points, please add a \`dormant\` or \`retired\` life cycle badge.

--- a/__tests__/__snapshots__/templates.test.ts.snap
+++ b/__tests__/__snapshots__/templates.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Template Snapshots Loads the expected template for inactive repository issues 1`] = `
+"This issue is a kind reminder that your repository has been inactive for 1 days. Some repositories are maintained in accordance with business requirements that infrequently change thus appearing inactive, and some repositories are inactive because they are unmaintained.
+
+To help differentiate products that are unmaintained from products that do not require frequent maintenance, repomountie will open an issue whenever a repository has not been updated in 2 days.
+
+- If this product is being actively maintained, please close this issue.
+- If this repository isn't being actively maintained anymore, please archive this repository. Also, for bonus points, please add a \`dormant\` or \`retired\` life cycle badge.
+
+Thank you for your help ensuring effective governance of our open-source ecosystem!
+"
+`;

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -16,17 +16,19 @@
 // Created by Jon Langlois on 2021-05-12.
 //
 
-import template from 'lodash/template';
-import { TEXT_FILES } from '../src/constants';
-import { loadTemplate } from '../src/libs/utils';
+import template from "lodash/template";
+import { TEXT_FILES } from "../src/constants";
+import { loadTemplate } from "../src/libs/utils";
 
-describe('Template Snapshots', () => {
-  it('Loads the expected template for inactive repository issues', async () => {
-    const inactiveIssueText: string = await loadTemplate(TEXT_FILES.INACTIVE_REPO);
+describe("Template Snapshots", () => {
+  it("Loads the expected template for inactive repository issues", async () => {
+    const inactiveIssueText: string = await loadTemplate(
+      TEXT_FILES.INACTIVE_REPO
+    );
     expect(
       template(inactiveIssueText)({
-        daysInactive: 1,
-        daysInactiveLimit: 2,
+        daysInactive: 14,
+        daysInactiveLimit: 7,
       })
     ).toMatchSnapshot();
   });

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -1,0 +1,33 @@
+//
+// Copyright © 2018, 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Jon Langlois on 2021-05-12.
+//
+
+import template from 'lodash/template';
+import { TEXT_FILES } from '../src/constants';
+import { loadTemplate } from '../src/libs/utils';
+
+describe('Template Snapshots', () => {
+  it('Loads the expected template for inactive repository issues', async () => {
+    const inactiveIssueText: string = await loadTemplate(TEXT_FILES.INACTIVE_REPO);
+    expect(
+      template(inactiveIssueText)({
+        daysInactive: 1,
+        daysInactiveLimit: 2,
+      })
+    ).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
creation of a snapshot test for inactive issue template and updated
header files.

I was thinking this test might be useful to ensure the template is still loading information correctly